### PR TITLE
Add compatibility module for Reflex app discovery

### DIFF
--- a/portfolio_app/portfolio_app.py
+++ b/portfolio_app/portfolio_app.py
@@ -1,0 +1,9 @@
+"""Compatibility module for Reflex app discovery.
+
+Reflex resolves app modules as `<app_name>.<app_name>` based on `rxconfig.py`.
+This module re-exports the canonical `app` instance from `portfolio_app.app`.
+"""
+
+from .app import app
+
+__all__ = ["app"]


### PR DESCRIPTION
### Motivation
- Resolve `ModuleNotFoundError` raised when Reflex expects `portfolio_app.portfolio_app` because `app_name="portfolio_app"` in `rxconfig.py`.

### Description
- Add `portfolio_app/portfolio_app.py` which re-exports the canonical `app` instance via `from .app import app` and exposes `__all__ = ["app"]` to satisfy Reflex app discovery.

### Testing
- Ran `python3 -m py_compile portfolio_app/portfolio_app.py` which succeeded, and attempted `uvx --from ruff ruff check .` and an import test via `uv run python -c "import importlib; m=importlib.import_module('portfolio_app.portfolio_app'); print(hasattr(m,'app'))"` but the latter checks were blocked/failed due to network/PyPI access in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d978c65c8330a025c09eef07d788)