### PR TITLE
[codex] Fix GitHub Pages publish root

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EXPORT_ROOT: .web/build/client
+      ROUTE_DIR: .web/build/client/portfolioMauricioobgo
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -26,11 +28,30 @@ jobs:
       - run: uv sync --frozen
       - run: uv run python -m portfolio_app.scripts.sync_data --scope all
       - run: uv run reflex export --frontend-only --no-zip
-      - run: New-Item -ItemType File -Path .web/build/client/.nojekyll -Force | Out-Null
-        shell: pwsh
+      - name: Prepare publish folder
+        id: publish
+        run: |
+          publish_dir="$EXPORT_ROOT"
+
+          if [[ -f "$EXPORT_ROOT/index.html" ]]; then
+            publish_dir="$EXPORT_ROOT"
+          elif [[ -f "$ROUTE_DIR/index.html" && -f "$ROUTE_DIR/404.html" && -f "$ROUTE_DIR/manifest.json" && -d "$ROUTE_DIR/assets" ]]; then
+            publish_dir="$ROUTE_DIR"
+          elif [[ -f "$ROUTE_DIR/index.html" ]]; then
+            cp "$ROUTE_DIR/index.html" "$EXPORT_ROOT/index.html"
+          fi
+
+          test -f "$publish_dir/index.html"
+          test -f "$publish_dir/404.html"
+          test -f "$publish_dir/manifest.json"
+          test -d "$publish_dir/assets"
+
+          touch "$publish_dir/.nojekyll"
+          echo "publish_dir=$publish_dir" >> "$GITHUB_OUTPUT"
+        shell: bash
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: .web/build/client
+          folder: ${{ steps.publish.outputs.publish_dir }}
           clean: true
           single-commit: true

--- a/.github/workflows/refresh-gh-pages.yml
+++ b/.github/workflows/refresh-gh-pages.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EXPORT_ROOT: .web/build/client
+      ROUTE_DIR: .web/build/client/portfolioMauricioobgo
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -49,11 +51,30 @@ jobs:
         shell: bash
       - run: uv run python -m portfolio_app.scripts.sync_data --scope ${{ steps.scope.outputs.sync_scope }}
       - run: uv run reflex export --frontend-only --no-zip
-      - run: New-Item -ItemType File -Path .web/build/client/.nojekyll -Force | Out-Null
-        shell: pwsh
+      - name: Prepare publish folder
+        id: publish
+        run: |
+          publish_dir="$EXPORT_ROOT"
+
+          if [[ -f "$EXPORT_ROOT/index.html" ]]; then
+            publish_dir="$EXPORT_ROOT"
+          elif [[ -f "$ROUTE_DIR/index.html" && -f "$ROUTE_DIR/404.html" && -f "$ROUTE_DIR/manifest.json" && -d "$ROUTE_DIR/assets" ]]; then
+            publish_dir="$ROUTE_DIR"
+          elif [[ -f "$ROUTE_DIR/index.html" ]]; then
+            cp "$ROUTE_DIR/index.html" "$EXPORT_ROOT/index.html"
+          fi
+
+          test -f "$publish_dir/index.html"
+          test -f "$publish_dir/404.html"
+          test -f "$publish_dir/manifest.json"
+          test -d "$publish_dir/assets"
+
+          touch "$publish_dir/.nojekyll"
+          echo "publish_dir=$publish_dir" >> "$GITHUB_OUTPUT"
+        shell: bash
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: .web/build/client
+          folder: ${{ steps.publish.outputs.publish_dir }}
           clean: true
           single-commit: true

--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -48,10 +48,7 @@ app.add_page(
     home_page,
     route="/",
     title="Mauricio Obando | Data Engineering Portfolio",
-    description=(
-        "Data engineering, analytics, and cloud delivery portfolio for "
-        "Mauricio Obando."
-    ),
+    description=("Data engineering, analytics, and cloud delivery portfolio for Mauricio Obando."),
     image="android-chrome-384x384.png",
     meta=[
         {"name": "twitter:card", "content": "summary_large_image"},

--- a/portfolio_app/pages/home.py
+++ b/portfolio_app/pages/home.py
@@ -89,7 +89,9 @@ def _hero(profile: dict, generated_profile: dict, refresh_log: dict) -> rx.Compo
                     wrap="wrap",
                 ),
                 rx.hstack(
-                    rx.link("GitHub", href=social_links["github"], is_external=True, color="#102033"),
+                    rx.link(
+                        "GitHub", href=social_links["github"], is_external=True, color="#102033"
+                    ),
                     rx.text("•", color="#94a3b8"),
                     rx.link(
                         "LinkedIn",
@@ -97,43 +99,55 @@ def _hero(profile: dict, generated_profile: dict, refresh_log: dict) -> rx.Compo
                         is_external=True,
                         color="#102033",
                     ),
-                    *((
-                        rx.text("•", color="#94a3b8"),
-                        rx.text(location, color="#475569"),
-                    ) if location else ()),
+                    *(
+                        (
+                            rx.text("•", color="#94a3b8"),
+                            rx.text(location, color="#475569"),
+                        )
+                        if location
+                        else ()
+                    ),
                     spacing="3",
                     wrap="wrap",
                 ),
-                *((
-                    rx.text(
-                        refresh_copy,
-                        color="#64748b",
-                        font_size="0.92rem",
-                    ),
-                ) if refresh_copy else ()),
+                *(
+                    (
+                        rx.text(
+                            refresh_copy,
+                            color="#64748b",
+                            font_size="0.92rem",
+                        ),
+                    )
+                    if refresh_copy
+                    else ()
+                ),
                 align="start",
                 spacing="5",
                 width="100%",
                 max_width="42rem",
             ),
-            *((
-                rx.box(
-                    rx.image(
-                        src=avatar_url,
-                        alt=f"{profile['name']} GitHub avatar",
-                        width="100%",
-                        height="100%",
-                        object_fit="cover",
+            *(
+                (
+                    rx.box(
+                        rx.image(
+                            src=avatar_url,
+                            alt=f"{profile['name']} GitHub avatar",
+                            width="100%",
+                            height="100%",
+                            object_fit="cover",
+                        ),
+                        width="220px",
+                        height="220px",
+                        border_radius="28px",
+                        overflow="hidden",
+                        box_shadow="0 28px 60px rgba(16, 32, 51, 0.16)",
+                        border="1px solid rgba(255, 255, 255, 0.5)",
+                        flex_shrink="0",
                     ),
-                    width="220px",
-                    height="220px",
-                    border_radius="28px",
-                    overflow="hidden",
-                    box_shadow="0 28px 60px rgba(16, 32, 51, 0.16)",
-                    border="1px solid rgba(255, 255, 255, 0.5)",
-                    flex_shrink="0",
-                ),
-            ) if avatar_url else ()),
+                )
+                if avatar_url
+                else ()
+            ),
             width="100%",
             justify="between",
             align="center",
@@ -143,9 +157,7 @@ def _hero(profile: dict, generated_profile: dict, refresh_log: dict) -> rx.Compo
         width="100%",
         padding="2rem",
         border_radius="32px",
-        background=(
-            "linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(255, 255, 255, 0.88))"
-        ),
+        background=("linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(255, 255, 255, 0.88))"),
         border="1px solid rgba(255, 255, 255, 0.54)",
         box_shadow="0 32px 80px rgba(16, 32, 51, 0.12)",
     )
@@ -192,15 +204,19 @@ def _project_grid(title: str, items: list[dict], empty_state: str) -> rx.Compone
                     rx.box(
                         rx.heading(item["name"], size="5", color="#102033"),
                         rx.text(item["summary"], color="#475569"),
-                        *([
-                            rx.link(
-                                "Open repository",
-                                href=item["html_url"],
-                                is_external=True,
-                                color="#c06a15",
-                                font_weight="700",
-                            )
-                        ] if item.get("html_url") else []),
+                        *(
+                            [
+                                rx.link(
+                                    "Open repository",
+                                    href=item["html_url"],
+                                    is_external=True,
+                                    color="#c06a15",
+                                    font_weight="700",
+                                )
+                            ]
+                            if item.get("html_url")
+                            else []
+                        ),
                         padding="1.25rem",
                         border_radius="20px",
                         background="rgba(255, 255, 255, 0.82)",

--- a/portfolio_app/scripts/sync_data.py
+++ b/portfolio_app/scripts/sync_data.py
@@ -43,11 +43,13 @@ def run_sync(
     if scope in {"monthly", "all"}:
         user = fetch_user_fn(login)
         (out_dir / "profile.json").write_text(json.dumps(user, indent=2), encoding="utf-8")
-        refresh_log["updates"].extend([
-            "profile_monthly_review",
-            "linkedin_monthly_review",
-            "certifications_monthly_review",
-        ])
+        refresh_log["updates"].extend(
+            [
+                "profile_monthly_review",
+                "linkedin_monthly_review",
+                "certifications_monthly_review",
+            ]
+        )
 
     (out_dir / "refresh_log.json").write_text(
         json.dumps(refresh_log, indent=2),


### PR DESCRIPTION
## Summary
- fix the GitHub Pages deploy workflows so they publish a verified site root to `gh-pages`
- normalize the Reflex export layout when `index.html` is emitted under `portfolioMauricioobgo/`
- apply Ruff formatting updates required for CI to pass on the same branch

## Root Cause
The deployed `gh-pages` branch could end up with the route HTML nested under `portfolioMauricioobgo/index.html` while GitHub Pages was serving the branch root. That left the published source without a usable root-level `index.html`, which caused the project site URL to return 404.

## Changes
- update `deploy-gh-pages.yml` to detect the export shape, ensure the publish directory contains `index.html`, `404.html`, `manifest.json`, `assets/`, and `.nojekyll`, and deploy that verified directory
- apply the same publish-root normalization to `refresh-gh-pages.yml`
- format `portfolio_app/app.py`, `portfolio_app/pages/home.py`, and `portfolio_app/scripts/sync_data.py` so the branch passes Ruff format checks

## Validation
- `uvx --from ruff ruff check .`
- `uvx --from ruff ruff format --check .`
- `uvx --with . --from pytest python -m pytest -q`

## Notes
- local Windows `reflex export` still hits Reflex's `PosixPath` bug after the production build completes, so the final end-to-end export confirmation will come from the Ubuntu GitHub Actions runner
- after merge, GitHub Pages should remain configured as `Deploy from a branch` using `gh-pages` and `/(root)`