### PR TITLE
[codex] Refresh portfolio content and AI dashboard design

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1,31 +1,377 @@
 :root {
-  --portfolio-ink: #102033;
-  --portfolio-muted: #475569;
-  --portfolio-accent: #c06a15;
-  --portfolio-paper: rgba(255, 255, 255, 0.82);
+  --bg-0: #04070d;
+  --bg-1: #09111d;
+  --bg-2: #101b2a;
+  --panel: rgba(9, 17, 29, 0.78);
+  --panel-strong: rgba(7, 12, 22, 0.92);
+  --line: rgba(90, 255, 220, 0.16);
+  --line-strong: rgba(90, 255, 220, 0.34);
+  --text-0: #f5fbff;
+  --text-1: #b6c7d9;
+  --text-2: #7d94ab;
+  --accent-a: #54f3d1;
+  --accent-b: #6ec7ff;
+  --accent-c: #f9b44c;
 }
 
 html {
   background:
-    radial-gradient(circle at top left, rgba(245, 158, 11, 0.18), transparent 30%),
-    radial-gradient(circle at top right, rgba(14, 116, 144, 0.16), transparent 26%),
-    linear-gradient(180deg, #f7f3ec 0%, #eef3f6 100%);
+    radial-gradient(circle at 15% 18%, rgba(84, 243, 209, 0.18), transparent 24%),
+    radial-gradient(circle at 82% 12%, rgba(110, 199, 255, 0.17), transparent 22%),
+    radial-gradient(circle at 78% 72%, rgba(249, 180, 76, 0.12), transparent 20%),
+    linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 44%, #060a12 100%);
 }
 
 body {
-  color: var(--portfolio-ink);
+  color: var(--text-0);
   background: transparent;
   font-family:
     "IBM Plex Sans",
     "Segoe UI",
     sans-serif;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(84, 243, 209, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(84, 243, 209, 0.04) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
+  opacity: 0.6;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(84, 243, 209, 0.03) 46%,
+    rgba(84, 243, 209, 0.12) 50%,
+    rgba(84, 243, 209, 0.03) 54%,
+    transparent 100%
+  );
+  animation: scanline 12s linear infinite;
+  opacity: 0.55;
 }
 
 a {
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.16em;
+  color: var(--text-0);
+  text-decoration: none;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+a:hover {
+  color: var(--accent-a);
 }
 
 ::selection {
-  background: rgba(245, 158, 11, 0.28);
+  background: rgba(84, 243, 209, 0.28);
+  color: var(--text-0);
+}
+
+.portfolio-shell {
+  position: relative;
+}
+
+.hero-shell,
+.section-shell,
+.metric-card,
+.flow-card,
+.timeline-card,
+.project-card,
+.repo-card,
+.cert-card,
+.avatar-shell {
+  backdrop-filter: blur(18px);
+}
+
+.hero-shell {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 32px;
+  background:
+    linear-gradient(145deg, rgba(11, 22, 36, 0.94), rgba(7, 13, 22, 0.92)),
+    linear-gradient(145deg, rgba(84, 243, 209, 0.05), transparent 45%);
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.44),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero-grid-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(84, 243, 209, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(84, 243, 209, 0.04) 1px, transparent 1px);
+  background-size: 26px 26px;
+  opacity: 0.38;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-eyebrow,
+.section-eyebrow,
+.metric-label,
+.flow-title,
+.project-label,
+.repo-label,
+.timeline-date,
+.cert-issuer {
+  font-family:
+    "IBM Plex Mono",
+    "Consolas",
+    monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.hero-eyebrow {
+  color: var(--accent-a);
+  font-size: 0.78rem;
+}
+
+.hero-name {
+  color: var(--text-0);
+  line-height: 0.98;
+  max-width: 12ch;
+}
+
+.hero-title {
+  color: var(--accent-b);
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
+.hero-subtitle,
+.hero-about,
+.timeline-copy,
+.project-copy,
+.repo-copy,
+.flow-copy {
+  color: var(--text-1);
+}
+
+.hero-subtitle {
+  font-size: 1.06rem;
+  max-width: 48rem;
+}
+
+.hero-about {
+  max-width: 48rem;
+  line-height: 1.75;
+}
+
+.hero-meta {
+  color: var(--text-2);
+  font-family:
+    "IBM Plex Mono",
+    "Consolas",
+    monospace;
+  font-size: 0.9rem;
+}
+
+.command-pill {
+  border: 1px solid rgba(110, 199, 255, 0.22);
+  border-radius: 999px;
+  padding: 0.62rem 0.92rem;
+  background: rgba(8, 16, 26, 0.72);
+  color: var(--text-0);
+  font-weight: 600;
+}
+
+.action-primary,
+.action-secondary,
+.section-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.82rem 1.1rem;
+  font-family:
+    "IBM Plex Mono",
+    "Consolas",
+    monospace;
+  font-size: 0.92rem;
+  border: 1px solid transparent;
+}
+
+.action-primary {
+  background: linear-gradient(135deg, var(--accent-a), var(--accent-b));
+  color: #04121a;
+  font-weight: 700;
+}
+
+.action-secondary,
+.section-action {
+  background: rgba(9, 17, 29, 0.68);
+  border-color: rgba(110, 199, 255, 0.22);
+  color: var(--text-0);
+}
+
+.action-primary:hover,
+.action-secondary:hover,
+.section-action:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+
+.metric-card,
+.flow-card,
+.timeline-card,
+.project-card,
+.repo-card,
+.cert-card,
+.avatar-shell,
+.section-shell {
+  position: relative;
+  z-index: 1;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(7, 13, 22, 0.86), rgba(10, 18, 31, 0.94));
+  box-shadow:
+    0 20px 44px rgba(0, 0, 0, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.metric-card {
+  border-radius: 24px;
+  padding: 1rem;
+}
+
+.metric-label {
+  color: var(--text-2);
+  font-size: 0.72rem;
+}
+
+.metric-value,
+.section-title,
+.timeline-title,
+.project-title,
+.repo-title,
+.cert-title {
+  color: var(--text-0);
+}
+
+.metric-detail,
+.section-subtitle,
+.repo-meta,
+.timeline-location,
+.cert-meta,
+.empty-copy {
+  color: var(--text-2);
+}
+
+.avatar-shell {
+  width: 100%;
+  max-width: 360px;
+  height: 260px;
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+.flow-card {
+  flex: 1 1 240px;
+  border-radius: 22px;
+  padding: 1rem;
+  background:
+    linear-gradient(145deg, rgba(7, 14, 24, 0.92), rgba(9, 17, 29, 0.9)),
+    linear-gradient(90deg, rgba(84, 243, 209, 0.08), transparent 50%);
+}
+
+.flow-title {
+  color: var(--accent-c);
+  font-size: 0.72rem;
+}
+
+.section-shell {
+  border-radius: 28px;
+  padding: 1.4rem;
+}
+
+.section-eyebrow {
+  color: var(--accent-b);
+  font-size: 0.72rem;
+}
+
+.section-subtitle {
+  max-width: 44rem;
+}
+
+.timeline-card {
+  border-left: 2px solid var(--accent-a);
+  border-radius: 20px;
+  padding: 1.15rem;
+}
+
+.timeline-date {
+  color: var(--accent-c);
+  font-size: 0.72rem;
+}
+
+.timeline-company {
+  color: var(--accent-a);
+  font-weight: 700;
+}
+
+.timeline-marker {
+  color: var(--accent-a);
+  font-family:
+    "IBM Plex Mono",
+    "Consolas",
+    monospace;
+}
+
+.timeline-highlight {
+  color: var(--text-1);
+  line-height: 1.65;
+}
+
+.project-card,
+.repo-card,
+.cert-card {
+  flex: 1 1 280px;
+  border-radius: 22px;
+  padding: 1.15rem;
+}
+
+.project-label,
+.repo-label {
+  color: var(--accent-b);
+  font-size: 0.72rem;
+}
+
+.cert-issuer {
+  color: var(--accent-a);
+  font-size: 0.72rem;
+}
+
+@keyframes scanline {
+  0% {
+    transform: translateY(-55%);
+  }
+
+  100% {
+    transform: translateY(55%);
+  }
 }

--- a/portfolio_app/components/sections.py
+++ b/portfolio_app/components/sections.py
@@ -1,9 +1,41 @@
 import reflex as rx
 
 
-def section(title: str, *children: rx.Component) -> rx.Component:
+def section(
+    title: str,
+    *children: rx.Component,
+    eyebrow: str | None = None,
+    subtitle: str | None = None,
+    action_label: str | None = None,
+    action_url: str | None = None,
+) -> rx.Component:
     return rx.box(
-        rx.heading(title, size="6", color="#102033"),
+        rx.flex(
+            rx.vstack(
+                *([rx.text(eyebrow, class_name="section-eyebrow")] if eyebrow else []),
+                rx.heading(title, size="6", class_name="section-title"),
+                *([rx.text(subtitle, class_name="section-subtitle")] if subtitle else []),
+                spacing="1",
+                align="start",
+            ),
+            *(
+                [
+                    rx.link(
+                        action_label,
+                        href=action_url,
+                        is_external=True,
+                        class_name="section-action",
+                    )
+                ]
+                if action_label and action_url
+                else []
+            ),
+            width="100%",
+            justify="between",
+            align="start",
+            gap="1rem",
+            wrap="wrap",
+        ),
         rx.vstack(
             *children,
             spacing="4",
@@ -12,9 +44,5 @@ def section(title: str, *children: rx.Component) -> rx.Component:
         ),
         width="100%",
         padding="1.5rem",
-        border="1px solid rgba(16, 32, 51, 0.08)",
-        border_radius="24px",
-        background="rgba(255, 255, 255, 0.76)",
-        box_shadow="0 24px 60px rgba(16, 32, 51, 0.08)",
-        backdrop_filter="blur(18px)",
+        class_name="section-shell",
     )

--- a/portfolio_app/data/certifications.yaml
+++ b/portfolio_app/data/certifications.yaml
@@ -1,3 +1,21 @@
-- title: AWS Certified Solutions Architect
-  issuer: Amazon Web Services
-  credential_url: https://www.credly.com/
+- title: DS4A / Colombia 6.0
+  issuer: Correlation One
+  issued: Jul 2022
+  credential_id: "54847879"
+  credential_url: https://www.linkedin.com/in/mauricioobgo/details/certifications/
+  credential_label: View on LinkedIn
+- title: Google Analytics Beginners
+  issuer: Google
+  issued: Jul 2020
+  credential_url: https://www.linkedin.com/in/mauricioobgo/details/certifications/
+  credential_label: View on LinkedIn
+- title: Introduction to TensorFlow for Artificial Intelligence, Machine Learning, and Deep Learning
+  issuer: Coursera
+  issued: Jul 2020
+  credential_url: https://www.linkedin.com/in/mauricioobgo/details/certifications/
+  credential_label: View on LinkedIn
+- title: Best student award
+  issuer: Universidad de la Sabana
+  issued: Oct 2013
+  credential_url: https://www.linkedin.com/in/mauricioobgo/details/certifications/
+  credential_label: View on LinkedIn

--- a/portfolio_app/data/experience.yaml
+++ b/portfolio_app/data/experience.yaml
@@ -1,8 +1,35 @@
+- role: Data Engineer
+  company: Globant
+  date: Current role listed on LinkedIn
+  location: Bogota, Colombia
+  description: Public LinkedIn profile currently lists Globant as the active company, with Mauricio positioned around modern data engineering and AI-oriented delivery.
+  highlights:
+    - Public LinkedIn profile shows Globant as the current employer.
+    - Focused on practical AI workflows, cloud-native delivery, and modern data engineering.
+  company_url: https://www.globant.com/
+  reference_url: https://www.linkedin.com/in/mauricioobgo/
+  reference_label: LinkedIn
 - role: Technical Account Manager
-  company: AWS
-  date: May 2024 - Present
-  description: Assist clients with AWS architecture and Well-Architected best practices.
-- role: Lead Data Engineer
-  company: Publicis Groupe
+  company: Amazon Web Services
+  date: May 2024 - Recent
+  location: Colombia
+  description: Worked with AWS customers on architecture reliability, Well-Architected guidance, cost optimization, and cloud intelligence practices.
+  highlights:
+    - Delivered recommendations across resiliency, security, and operational excellence.
+    - Built cost and usage visibility workflows with Python, Athena, Glue, S3, and QuickSight.
+    - Supported migrations and service adoption with architecture guidance tailored to client workloads.
+  company_url: https://aws.amazon.com/
+  reference_url: https://www.linkedin.com/in/mauricioobgo/
+  reference_label: LinkedIn
+- role: Data Engineer Specialist
+  company: Publicis Media
   date: Feb 2023 - May 2024
-  description: Led ingestion and transformation pipelines for analytics and data science use cases.
+  location: Hybrid delivery
+  description: Designed and operated high-value data pipelines, dashboard architectures, and marketing analytics workflows for major client programs.
+  highlights:
+    - Built data ingestion and transformation pipelines for Stellantis programs on AWS and GCP.
+    - Created architecture patterns for Tableau and Looker-based insight delivery.
+    - Developed a classification model for marketing moments to purchase from Google Ads interaction data.
+  company_url: https://www.publicismedia.com/
+  reference_url: https://www.linkedin.com/in/mauricioobgo/
+  reference_label: LinkedIn

--- a/portfolio_app/data/profile.yaml
+++ b/portfolio_app/data/profile.yaml
@@ -1,12 +1,14 @@
 name: Mauricio Obando
-title: Hi all, I am Mauricio
-subtitle: "My passion for Data Engineering, Data Science, and Cloud"
+title: AI-Ready Data Engineer
+subtitle: "Building cloud pipelines, analytics systems, and practical AI workflows."
+about: "Senior data engineer with 7+ years across cloud architecture, production pipelines, analytics platforms, and AI-assisted delivery."
 resume_link: "https://drive.google.com/file/d/197iszNCfu2tIdIlV5CLF--6Lk3bMSBFH/view?usp=sharing"
 email: mauricioobgo@gmail.com
 social_links:
   github: https://github.com/mauricioobgo
   linkedin: https://www.linkedin.com/in/mauricioobgo/
 skills:
-  - Data Engineering and Data Science
-  - Cloud architecture across AWS, GCP and Azure
-  - Python and Spark data pipelines
+  - AI-assisted engineering workflows
+  - Cloud data platforms on AWS and GCP
+  - Python, SQL, Spark, and DBT pipelines
+  - Analytics architecture and experimentation

--- a/portfolio_app/pages/home.py
+++ b/portfolio_app/pages/home.py
@@ -1,197 +1,277 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
 import reflex as rx
 
 from portfolio_app.components.sections import section
 from portfolio_app.services.content import load_portfolio_content
 
 
-CONTENT = load_portfolio_content()
+LINKEDIN_PROFILE_URL = "https://www.linkedin.com/in/mauricioobgo/"
+LINKEDIN_EXPERIENCE_URL = "https://www.linkedin.com/in/mauricioobgo/details/experience/"
+LINKEDIN_CERTIFICATIONS_URL = "https://www.linkedin.com/in/mauricioobgo/details/certifications/"
 
 
-def _hero(profile: dict, generated_profile: dict, refresh_log: dict) -> rx.Component:
+def _format_refresh(refresh_log: dict) -> str:
+    executed_at = refresh_log.get("executed_at")
+    scope = refresh_log.get("scope", "manual")
+    if not executed_at:
+        return "Refresh state unavailable"
+
+    try:
+        parsed = datetime.fromisoformat(executed_at.replace("Z", "+00:00"))
+        stamp = parsed.strftime("%b %d, %Y")
+    except ValueError:
+        stamp = executed_at
+
+    return f"{scope.upper()} refresh // {stamp}"
+
+
+def _format_repo_date(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.strftime("%b %d, %Y")
+    except ValueError:
+        return value
+
+
+def _estimate_years(experience: list[dict]) -> str:
+    if not experience:
+        return "n/a"
+
+    latest_match = re.search(r"(20\d{2})", experience[-1].get("date", ""))
+    if not latest_match:
+        return "7+ years"
+
+    start_year = int(latest_match.group(1))
+    years = max(datetime.now().year - start_year, 1)
+    return f"{years}+ years"
+
+
+def _command_pill(value: str) -> rx.Component:
+    return rx.box(value, class_name="command-pill")
+
+
+def _terminal_button(label: str, href: str, *, primary: bool = False) -> rx.Component:
+    return rx.link(
+        label,
+        href=href,
+        is_external=True,
+        class_name="action-primary" if primary else "action-secondary",
+    )
+
+
+def _metric_card(label: str, value: str, detail: str) -> rx.Component:
+    return rx.box(
+        rx.text(label, class_name="metric-label"),
+        rx.heading(value, size="6", class_name="metric-value"),
+        rx.text(detail, class_name="metric-detail"),
+        class_name="metric-card",
+    )
+
+
+def _flow_card(title: str, detail: str) -> rx.Component:
+    return rx.box(
+        rx.text(title, class_name="flow-title"),
+        rx.text(detail, class_name="flow-copy"),
+        class_name="flow-card",
+    )
+
+
+def _hero(
+    profile: dict,
+    generated_profile: dict,
+    refresh_log: dict,
+    experience: list[dict],
+    certifications: list[dict],
+    generated_repos: list[dict],
+) -> rx.Component:
     social_links = profile["social_links"]
-    refresh_copy = ""
-    if refresh_log:
-        refresh_copy = (
-            f"Last refresh: {refresh_log['scope']} cadence at {refresh_log['executed_at']}"
-        )
-
+    refresh_copy = _format_refresh(refresh_log)
     avatar_url = generated_profile.get("avatar_url")
-    location = generated_profile.get("location")
+    location = generated_profile.get("location", "Bogota, Colombia")
+    current_company = experience[0]["company"] if experience else "Available on LinkedIn"
+
+    metrics = [
+        (
+            "current node",
+            current_company,
+            experience[0].get("date", "latest profile snapshot")
+            if experience
+            else "latest profile snapshot",
+        ),
+        ("career span", _estimate_years(experience), "data and cloud delivery"),
+        ("cert signals", str(len(certifications)), "LinkedIn-backed credentials"),
+        ("repo feed", str(len(generated_repos[:6])), refresh_copy),
+    ]
 
     return rx.box(
+        rx.box(class_name="hero-grid-overlay"),
         rx.flex(
             rx.vstack(
-                rx.text(
-                    "Python-first portfolio",
-                    text_transform="uppercase",
-                    letter_spacing="0.24em",
-                    color="#c06a15",
-                    font_weight="700",
-                    font_size="0.8rem",
-                ),
-                rx.heading(
-                    profile["name"],
-                    size="9",
-                    color="#102033",
-                    line_height="1.05",
-                ),
-                rx.heading(
-                    profile["title"],
-                    size="7",
-                    color="#334155",
-                    line_height="1.1",
-                ),
-                rx.text(
-                    profile["subtitle"],
-                    color="#475569",
-                    font_size="1.1rem",
-                    max_width="42rem",
-                ),
-                rx.hstack(
-                    *[
-                        rx.box(
-                            skill,
-                            padding="0.5rem 0.8rem",
-                            border_radius="999px",
-                            background="rgba(255, 255, 255, 0.72)",
-                            border="1px solid rgba(16, 32, 51, 0.08)",
-                            color="#102033",
-                            font_weight="600",
-                        )
-                        for skill in profile["skills"]
-                    ],
+                rx.text("AI PORTFOLIO // LIVE PROFILE", class_name="hero-eyebrow"),
+                rx.heading(profile["name"], size="9", class_name="hero-name"),
+                rx.text(profile["title"], class_name="hero-title"),
+                rx.text(profile["subtitle"], class_name="hero-subtitle"),
+                rx.text(profile["about"], class_name="hero-about"),
+                rx.flex(
+                    *[_command_pill(skill) for skill in profile["skills"]],
                     wrap="wrap",
-                    spacing="3",
+                    gap="0.7rem",
+                    width="100%",
                 ),
-                rx.hstack(
-                    rx.link(
-                        "View resume",
-                        href=profile["resume_link"],
-                        is_external=True,
-                        padding="0.85rem 1.2rem",
-                        border_radius="999px",
-                        background="#102033",
-                        color="white",
-                        font_weight="700",
-                        text_decoration="none",
-                    ),
-                    rx.link(
-                        "Send email",
-                        href=f"mailto:{profile['email']}",
-                        padding="0.85rem 1.2rem",
-                        border_radius="999px",
-                        border="1px solid rgba(16, 32, 51, 0.14)",
-                        color="#102033",
-                        font_weight="700",
-                        text_decoration="none",
-                    ),
-                    spacing="3",
+                rx.flex(
+                    _terminal_button("View resume", profile["resume_link"], primary=True),
+                    _terminal_button("Open LinkedIn", social_links["linkedin"]),
+                    _terminal_button("GitHub", social_links["github"]),
                     wrap="wrap",
+                    gap="0.8rem",
+                    width="100%",
                 ),
-                rx.hstack(
-                    rx.link(
-                        "GitHub", href=social_links["github"], is_external=True, color="#102033"
-                    ),
-                    rx.text("•", color="#94a3b8"),
-                    rx.link(
-                        "LinkedIn",
-                        href=social_links["linkedin"],
-                        is_external=True,
-                        color="#102033",
-                    ),
-                    *(
-                        (
-                            rx.text("•", color="#94a3b8"),
-                            rx.text(location, color="#475569"),
-                        )
-                        if location
-                        else ()
-                    ),
-                    spacing="3",
+                rx.flex(
+                    rx.text(f"mail // {profile['email']}", class_name="hero-meta"),
+                    rx.text(f"location // {location}", class_name="hero-meta"),
+                    rx.text(refresh_copy, class_name="hero-meta"),
                     wrap="wrap",
-                ),
-                *(
-                    (
-                        rx.text(
-                            refresh_copy,
-                            color="#64748b",
-                            font_size="0.92rem",
-                        ),
-                    )
-                    if refresh_copy
-                    else ()
+                    gap="0.8rem",
+                    width="100%",
                 ),
                 align="start",
                 spacing="5",
                 width="100%",
-                max_width="42rem",
+                class_name="hero-copy",
             ),
-            *(
-                (
-                    rx.box(
-                        rx.image(
-                            src=avatar_url,
-                            alt=f"{profile['name']} GitHub avatar",
-                            width="100%",
-                            height="100%",
-                            object_fit="cover",
-                        ),
-                        width="220px",
-                        height="220px",
-                        border_radius="28px",
-                        overflow="hidden",
-                        box_shadow="0 28px 60px rgba(16, 32, 51, 0.16)",
-                        border="1px solid rgba(255, 255, 255, 0.5)",
-                        flex_shrink="0",
-                    ),
-                )
-                if avatar_url
-                else ()
+            rx.vstack(
+                *[_metric_card(label, value, detail) for label, value, detail in metrics],
+                *(
+                    [
+                        rx.box(
+                            rx.image(
+                                src=avatar_url,
+                                alt=f"{profile['name']} avatar",
+                                width="100%",
+                                height="100%",
+                                object_fit="cover",
+                            ),
+                            class_name="avatar-shell",
+                        )
+                    ]
+                    if avatar_url
+                    else []
+                ),
+                width=["100%", "100%", "360px"],
+                spacing="4",
+                align="stretch",
             ),
             width="100%",
             justify="between",
-            align="center",
-            gap="2rem",
+            align="start",
+            gap="1.2rem",
             wrap="wrap",
         ),
-        width="100%",
-        padding="2rem",
-        border_radius="32px",
-        background=("linear-gradient(135deg, rgba(245, 158, 11, 0.18), rgba(255, 255, 255, 0.88))"),
-        border="1px solid rgba(255, 255, 255, 0.54)",
-        box_shadow="0 32px 80px rgba(16, 32, 51, 0.12)",
+        rx.flex(
+            _flow_card(
+                "AI mode",
+                "Practical LLM workflows, automation, and shipping-focused experimentation.",
+            ),
+            _flow_card(
+                "Data systems",
+                "Batch and analytics pipelines shaped for cloud-native scale and reliability.",
+            ),
+            _flow_card(
+                "Flow design",
+                "Terminal texture, bento rhythm, and connective lines inspired by current AI dashboard patterns.",
+            ),
+            wrap="wrap",
+            gap="1rem",
+            width="100%",
+        ),
+        class_name="hero-shell",
+    )
+
+
+def _experience_card(item: dict) -> rx.Component:
+    links: list[rx.Component] = []
+    if item.get("company_url"):
+        links.append(_terminal_button("Company", item["company_url"]))
+    if item.get("reference_url"):
+        links.append(
+            _terminal_button(
+                item.get("reference_label", "LinkedIn"),
+                item["reference_url"],
+            )
+        )
+
+    return rx.box(
+        rx.text(item["date"], class_name="timeline-date"),
+        rx.flex(
+            rx.vstack(
+                rx.heading(item["role"], size="5", class_name="timeline-title"),
+                rx.text(item["company"], class_name="timeline-company"),
+                *(
+                    [rx.text(item["location"], class_name="timeline-location")]
+                    if item.get("location")
+                    else []
+                ),
+                align="start",
+                spacing="1",
+            ),
+            width="100%",
+            justify="between",
+            align="start",
+            wrap="wrap",
+            gap="0.8rem",
+        ),
+        rx.text(item["description"], class_name="timeline-copy"),
+        rx.vstack(
+            *[
+                rx.flex(
+                    rx.text("> ", class_name="timeline-marker"),
+                    rx.text(highlight, class_name="timeline-highlight"),
+                    gap="0.2rem",
+                    align="start",
+                )
+                for highlight in item.get("highlights", [])
+            ],
+            spacing="2",
+            align="stretch",
+            width="100%",
+        ),
+        *(
+            [
+                rx.flex(
+                    *links,
+                    wrap="wrap",
+                    gap="0.8rem",
+                    width="100%",
+                )
+            ]
+            if links
+            else []
+        ),
+        class_name="timeline-card",
     )
 
 
 def _experience_section(experience: list[dict]) -> rx.Component:
     return section(
-        "Experience",
-        *[
-            rx.box(
-                rx.hstack(
-                    rx.vstack(
-                        rx.heading(item["role"], size="5", color="#102033"),
-                        rx.text(item["company"], color="#c06a15", font_weight="700"),
-                        rx.text(item["description"], color="#475569"),
-                        align="start",
-                        spacing="2",
-                    ),
-                    rx.text(
-                        item["date"],
-                        color="#64748b",
-                        white_space="nowrap",
-                    ),
-                    width="100%",
-                    justify="between",
-                    align="start",
-                    gap="1rem",
-                    wrap="wrap",
-                ),
-                padding_bottom="1.2rem",
-                border_bottom="1px solid rgba(16, 32, 51, 0.08)",
-            )
-            for item in experience
-        ],
+        "Latest Experience Log",
+        *[_experience_card(item) for item in experience],
+        eyebrow="career timeline",
+        subtitle="Three most recent experience nodes, aligned to the current LinkedIn and resume snapshot.",
+        action_label="Open full LinkedIn experience",
+        action_url=LINKEDIN_EXPERIENCE_URL,
+    )
+
+
+def _project_card(item: dict) -> rx.Component:
+    return rx.box(
+        rx.text("featured build", class_name="project-label"),
+        rx.heading(item["name"], size="5", class_name="project-title"),
+        rx.text(item["summary"], class_name="project-copy"),
+        class_name="project-card",
     )
 
 
@@ -200,107 +280,155 @@ def _project_grid(title: str, items: list[dict], empty_state: str) -> rx.Compone
     if items:
         body = [
             rx.flex(
-                *[
-                    rx.box(
-                        rx.heading(item["name"], size="5", color="#102033"),
-                        rx.text(item["summary"], color="#475569"),
-                        *(
-                            [
-                                rx.link(
-                                    "Open repository",
-                                    href=item["html_url"],
-                                    is_external=True,
-                                    color="#c06a15",
-                                    font_weight="700",
-                                )
-                            ]
-                            if item.get("html_url")
-                            else []
-                        ),
-                        padding="1.25rem",
-                        border_radius="20px",
-                        background="rgba(255, 255, 255, 0.82)",
-                        border="1px solid rgba(16, 32, 51, 0.08)",
-                        box_shadow="0 18px 40px rgba(16, 32, 51, 0.06)",
-                        flex="1 1 280px",
-                    )
-                    for item in items
-                ],
+                *[_project_card(item) for item in items],
                 wrap="wrap",
                 gap="1rem",
                 width="100%",
             )
         ]
     else:
-        body = [rx.text(empty_state, color="#64748b")]
+        body = [rx.text(empty_state, class_name="empty-copy")]
 
-    return section(title, *body)
+    return section(
+        title,
+        *body,
+        eyebrow="selected systems",
+        subtitle="Curated delivery highlights with product, analytics, and platform emphasis.",
+    )
+
+
+def _repo_card(repo: dict) -> rx.Component:
+    stars = repo.get("stargazers_count", 0)
+    updated_at = repo.get("updated_at")
+
+    return rx.box(
+        rx.flex(
+            rx.text("live repo", class_name="repo-label"),
+            rx.text(f"stars // {stars}", class_name="repo-meta"),
+            width="100%",
+            justify="between",
+            align="center",
+            wrap="wrap",
+            gap="0.6rem",
+        ),
+        rx.heading(repo["name"], size="5", class_name="repo-title"),
+        rx.text(
+            repo.get("description") or "Recently updated GitHub repository.",
+            class_name="repo-copy",
+        ),
+        *(
+            [rx.text(f"updated // {_format_repo_date(updated_at)}", class_name="repo-meta")]
+            if updated_at
+            else []
+        ),
+        _terminal_button("Open repository", repo["html_url"]),
+        class_name="repo-card",
+    )
+
+
+def _repo_section(generated_repos: list[dict]) -> rx.Component:
+    if generated_repos:
+        body = [
+            rx.flex(
+                *[_repo_card(repo) for repo in generated_repos[:6]],
+                wrap="wrap",
+                gap="1rem",
+                width="100%",
+            )
+        ]
+    else:
+        body = [
+            rx.text(
+                "Run the weekly sync to publish fresh repository activity.", class_name="empty-copy"
+            )
+        ]
+
+    return section(
+        "GitHub Activity Feed",
+        *body,
+        eyebrow="weekly sync output",
+        subtitle="Fresh repository motion rendered straight from the generated GitHub snapshot.",
+        action_label="Open GitHub profile",
+        action_url="https://github.com/mauricioobgo",
+    )
+
+
+def _certification_card(item: dict) -> rx.Component:
+    return rx.box(
+        rx.text(item["issuer"], class_name="cert-issuer"),
+        rx.heading(item["title"], size="5", class_name="cert-title"),
+        *(
+            [rx.text(f"issued // {item['issued']}", class_name="cert-meta")]
+            if item.get("issued")
+            else []
+        ),
+        *(
+            [rx.text(f"credential id // {item['credential_id']}", class_name="cert-meta")]
+            if item.get("credential_id")
+            else []
+        ),
+        _terminal_button(
+            item.get("credential_label", "View credential"),
+            item["credential_url"],
+        ),
+        class_name="cert-card",
+    )
 
 
 def _certifications_section(certifications: list[dict]) -> rx.Component:
     return section(
-        "Certifications",
-        *[
-            rx.box(
-                rx.heading(item["title"], size="5", color="#102033"),
-                rx.text(item["issuer"], color="#475569"),
-                rx.link(
-                    "View credential",
-                    href=item["credential_url"],
-                    is_external=True,
-                    color="#c06a15",
-                    font_weight="700",
-                ),
-                padding="1.25rem",
-                border_radius="20px",
-                background="rgba(255, 255, 255, 0.82)",
-                border="1px solid rgba(16, 32, 51, 0.08)",
-            )
-            for item in certifications
-        ],
+        "Certifications and Recognition",
+        rx.flex(
+            *[_certification_card(item) for item in certifications],
+            wrap="wrap",
+            gap="1rem",
+            width="100%",
+        ),
+        eyebrow="linkedin credential log",
+        subtitle="Publicly visible certifications and recognition currently surfaced on LinkedIn.",
+        action_label="Open full LinkedIn certifications",
+        action_url=LINKEDIN_CERTIFICATIONS_URL,
     )
 
 
 def home_page() -> rx.Component:
-    profile = CONTENT["profile"]
-    generated_profile = CONTENT["generated_profile"]
-    refresh_log = CONTENT["refresh_log"]
-    generated_repos = CONTENT["generated_repos"]
-
-    latest_repos = [
-        {
-            "name": repo["name"],
-            "summary": repo.get("description") or "Recently updated GitHub repository.",
-            "html_url": repo["html_url"],
-        }
-        for repo in generated_repos[:6]
-    ]
+    content = load_portfolio_content()
+    profile = content["profile"]
+    generated_profile = content["generated_profile"]
+    refresh_log = content["refresh_log"]
+    experience = content["experience"]
+    certifications = content["certifications"]
+    generated_repos = content["generated_repos"]
 
     return rx.box(
         rx.container(
             rx.vstack(
-                _hero(profile, generated_profile, refresh_log),
-                _experience_section(CONTENT["experience"]),
+                _hero(
+                    profile,
+                    generated_profile,
+                    refresh_log,
+                    experience,
+                    certifications,
+                    generated_repos,
+                ),
+                _experience_section(experience),
                 _project_grid(
-                    "Featured Work",
-                    CONTENT["projects"],
+                    "Selected Delivery Systems",
+                    content["projects"],
                     "Curated project highlights will appear here.",
                 ),
-                _project_grid(
-                    "Latest GitHub Repositories",
-                    latest_repos,
-                    "Run the weekly sync to publish fresh repository activity.",
-                ),
-                _certifications_section(CONTENT["certifications"]),
+                _repo_section(generated_repos),
+                _certifications_section(certifications),
                 width="100%",
-                spacing="7",
+                spacing="6",
                 align="stretch",
             ),
-            max_width="1200px",
+            max_width="1240px",
             width="100%",
-            padding_x=["1.2rem", "1.5rem", "2rem"],
-            padding_y="2.5rem",
+            padding_x=["1rem", "1.3rem", "1.8rem"],
+            padding_y="2rem",
         ),
         min_height="100vh",
         width="100%",
+        class_name="portfolio-shell",
     )


### PR DESCRIPTION
## Summary
- refresh the portfolio content with richer public-profile data for experience and certifications
- redesign the homepage into a darker AI control-room / terminal dashboard aesthetic
- keep the current Globant entry intentionally conservative because the public sources confirmed the company but not an exact current title/date with enough confidence

## Content
- update the profile copy with a stronger AI-ready data engineering positioning
- replace the previous minimal experience list with three richer latest experience cards
- expand the certification list with multiple LinkedIn-visible items and richer credential metadata
- refresh the experience/certification content from public resume material plus public LinkedIn-visible signals

## Design
- redesign the homepage toward an AI control-room / terminal dashboard style
- add darker neon panel styling, grid texture, scanline motion, and stronger flow-based card layouts
- restructure hero, repo, experience, and certification sections into a more intentional bento-style composition

## Structure
- extend the shared section component to support eyebrow text, subtitles, and optional actions
- preserve the richer YAML-driven content model introduced by this branch
- keep the portfolio fully data-driven through the YAML content layer

## Validation
- `uvx --from ruff ruff check .`
- `uvx --from ruff ruff format --check .`
- `uvx --with . --from pytest python -m pytest -q`

## Known Limitation
- local Windows `uv run reflex export --frontend-only --no-zip` still fails on Reflex's `PosixPath` issue after the production build step, so the final export proof should come from the Linux GitHub Actions runner