### PR TITLE
fix(web): copy custom fonts into GitHub Pages bundle (blank-site fix)

### DIFF
--- a/portfolio_app/scripts/patch_web_bundle.py
+++ b/portfolio_app/scripts/patch_web_bundle.py
@@ -13,6 +13,8 @@ BUNDLE_RELATIVE_PATH = Path("assets/app/app.zip")
 PYTHON_WORKER_RELATIVE_PATH = Path("python-worker.js")
 PYTHON_LOADER_RELATIVE_PATH = Path("python.js")
 FLUTTER_BOOTSTRAP_RELATIVE_PATH = Path("flutter_bootstrap.js")
+FONTS_RELATIVE_PATH = Path("assets/fonts")
+SOURCE_FONTS_DIR = Path("src/assets/fonts")
 
 RUNTIME_MODULES = ("flet", "flet_lottie", "msgpack")
 RUNTIME_FILES = ("repath.py", "six.py")
@@ -87,6 +89,7 @@ class PatchSummary:
     worker_patched: bool
     python_loader_patched: bool
     bootstrap_patched: bool
+    fonts_copied: int
 
 
 def _module_root(module_name: str) -> Path:
@@ -235,6 +238,59 @@ def patch_flutter_bootstrap(bootstrap_path: Path) -> bool:
     raise RuntimeError("Unable to find _flutter.buildConfig in flutter_bootstrap.js.")
 
 
+def copy_fonts(web_root: Path) -> int:
+    """Copy the project custom fonts (Poppins / IBMPlexMono) into the built site.
+
+    Flet's `flet build web` only copies Flutter's default fonts into
+    ``build/web/assets/fonts/``. The deployed ``index.html`` exposes
+    ``fontFallbackBaseUrl: "assets/fonts/"`` and the running Flet app
+    references ``fonts/Poppins-Regular.ttf`` etc. via ``page.fonts`` —
+    those references 404 in production, which can cause Flet to render an
+    empty page on GitHub Pages.
+
+    Returns the number of font files copied.
+    """
+    source_dir = SOURCE_FONTS_DIR
+    target_dir = web_root / FONTS_RELATIVE_PATH
+    if not source_dir.is_dir():
+        # No custom fonts declared for this project — nothing to do.
+        return 0
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for source in sorted(source_dir.iterdir()):
+        if not source.is_file():
+            continue
+        if source.suffix.lower() not in {".ttf", ".otf"}:
+            continue
+        destination = target_dir / source.name
+        if destination.exists() and destination.read_bytes() == source.read_bytes():
+            continue
+        destination.write_bytes(source.read_bytes())
+        copied += 1
+    return copied
+
+
+def verify_fonts(web_root: Path) -> None:
+    """Ensure every source font ends up in the built site."""
+    source_dir = SOURCE_FONTS_DIR
+    if not source_dir.is_dir():
+        return
+    target_dir = web_root / FONTS_RELATIVE_PATH
+    missing = [
+        source.name
+        for source in sorted(source_dir.iterdir())
+        if source.is_file()
+        and source.suffix.lower() in {".ttf", ".otf"}
+        and not (target_dir / source.name).is_file()
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Built web bundle is missing custom fonts: {missing}. "
+            "patch_web_bundle.copy_fonts should have copied them."
+        )
+
+
 def verify_bundle(bundle_path: Path) -> None:
     if not bundle_path.exists():
         raise FileNotFoundError(f"Bundle not found: {bundle_path}")
@@ -287,6 +343,7 @@ def verify_web_build(web_root: Path) -> None:
     verify_python_worker(web_root / PYTHON_WORKER_RELATIVE_PATH)
     verify_python_loader(web_root / PYTHON_LOADER_RELATIVE_PATH)
     verify_flutter_bootstrap(web_root / FLUTTER_BOOTSTRAP_RELATIVE_PATH)
+    verify_fonts(web_root)
 
 
 def patch_web_build(web_root: Path) -> PatchSummary:
@@ -299,12 +356,14 @@ def patch_web_build(web_root: Path) -> PatchSummary:
     worker_patched = patch_python_worker(worker_path)
     python_loader_patched = patch_python_loader(loader_path)
     bootstrap_patched = patch_flutter_bootstrap(bootstrap_path)
+    fonts_copied = copy_fonts(web_root)
     verify_web_build(web_root)
     return PatchSummary(
         bundle_entries_added=bundle_entries_added,
         worker_patched=worker_patched,
         python_loader_patched=python_loader_patched,
         bootstrap_patched=bootstrap_patched,
+        fonts_copied=fonts_copied,
     )
 
 
@@ -329,7 +388,8 @@ def main() -> None:
         f"Patched {web_root} with {summary.bundle_entries_added} runtime files; "
         f"python-worker.js updated={summary.worker_patched}; "
         f"python.js updated={summary.python_loader_patched}; "
-        f"flutter_bootstrap.js updated={summary.bootstrap_patched}."
+        f"flutter_bootstrap.js updated={summary.bootstrap_patched}; "
+        f"{summary.fonts_copied} custom font(s) copied."
     )
 
 

--- a/tests/test_patch_web_bundle.py
+++ b/tests/test_patch_web_bundle.py
@@ -202,3 +202,63 @@ def test_verify_web_build_rejects_wasm_bootstrap(tmp_path) -> None:
 
     with pytest.raises(RuntimeError, match="WASM startup path"):
         patch_web_bundle.verify_web_build(web_root)
+
+
+def test_copy_fonts_copies_custom_fonts(tmp_path, monkeypatch) -> None:
+    """copy_fonts pulls every .ttf/.otf from src/assets/fonts/ into the web root."""
+    source_dir = tmp_path / "src" / "assets" / "fonts"
+    source_dir.mkdir(parents=True)
+    (source_dir / "Poppins-Regular.ttf").write_bytes(b"poppins-data")
+    (source_dir / "IBMPlexMono-Medium.ttf").write_bytes(b"ibm-plex-data")
+    # Non-font files should be ignored.
+    (source_dir / "README.md").write_text("ignore me", encoding="utf-8")
+
+    web_root = tmp_path / "build" / "web"
+
+    monkeypatch.setattr(patch_web_bundle, "SOURCE_FONTS_DIR", source_dir)
+    copied = patch_web_bundle.copy_fonts(web_root)
+
+    assert copied == 2
+    target = web_root / "assets" / "fonts"
+    assert (target / "Poppins-Regular.ttf").read_bytes() == b"poppins-data"
+    assert (target / "IBMPlexMono-Medium.ttf").read_bytes() == b"ibm-plex-data"
+    assert not (target / "README.md").exists()
+
+
+def test_copy_fonts_is_idempotent(tmp_path, monkeypatch) -> None:
+    """Re-running copy_fonts with unchanged sources should copy zero new files."""
+    source_dir = tmp_path / "src" / "assets" / "fonts"
+    source_dir.mkdir(parents=True)
+    (source_dir / "Poppins-Bold.ttf").write_bytes(b"bold")
+
+    web_root = tmp_path / "build" / "web"
+
+    monkeypatch.setattr(patch_web_bundle, "SOURCE_FONTS_DIR", source_dir)
+    assert patch_web_bundle.copy_fonts(web_root) == 1
+    # Second run: file already present with same bytes → no copy.
+    assert patch_web_bundle.copy_fonts(web_root) == 0
+
+
+def test_copy_fonts_handles_missing_source_dir(tmp_path, monkeypatch) -> None:
+    """If the project has no custom fonts, copy_fonts is a no-op."""
+    web_root = tmp_path / "build" / "web"
+    monkeypatch.setattr(patch_web_bundle, "SOURCE_FONTS_DIR", tmp_path / "does-not-exist")
+    assert patch_web_bundle.copy_fonts(web_root) == 0
+
+
+def test_verify_fonts_flags_missing_fonts(tmp_path, monkeypatch) -> None:
+    """verify_fonts raises when a source font is absent from the built site."""
+    source_dir = tmp_path / "src" / "assets" / "fonts"
+    source_dir.mkdir(parents=True)
+    (source_dir / "Poppins-Regular.ttf").write_bytes(b"poppins")
+
+    web_root = tmp_path / "build" / "web"
+    web_root.mkdir(parents=True)
+    # Built site is missing the custom font.
+    empty_fonts = web_root / "assets" / "fonts"
+    empty_fonts.mkdir(parents=True)
+    (empty_fonts / "MaterialIcons-Regular.otf").write_bytes(b"default")
+
+    monkeypatch.setattr(patch_web_bundle, "SOURCE_FONTS_DIR", source_dir)
+    with pytest.raises(RuntimeError, match="Poppins-Regular.ttf"):
+        patch_web_bundle.verify_fonts(web_root)


### PR DESCRIPTION
## Summary

The deployed site at https://mauricioobgo.github.io/portfolioMauricioobgo/ has been rendering blank for ~3 days. This PR fixes it.

## Root cause

`flet build web` only copies Flutter's default fonts (`MaterialIcons-Regular.otf`, `roboto.woff2`) into `build/web/assets/fonts/`. Meanwhile, the app's `src/portfolio/theme.py` registers four custom font families via `page.fonts`:

```python
page.fonts = {
    "Body": "fonts/Poppins-Regular.ttf",
    "Display": "fonts/Poppins-SemiBold.ttf",
    "DisplayBold": "fonts/Poppins-Bold.ttf",
    "Mono": "fonts/IBMPlexMono-Medium.ttf",
}
```

Flet resolves those relative to the deployed `fontFallbackBaseUrl: "assets/fonts/"`, so it ends up requesting `/assets/fonts/Poppins-Regular.ttf` (and 6 more). All 7 return 404 against the production build. Flet's font fallback silently fails, the Flutter shell never finishes booting, and you get a blank `<flt-glass-pane>` with no canvas and no Pyodide.

The deployed `index.html` was *correct* (it advertises the right `fontFallbackBaseUrl`); the fonts were simply never shipped.

## Fix

Extend `portfolio_app/scripts/patch_web_bundle.py` (the post-build step that already runs in CI between `flet build web` and the Pages upload) to copy every `.ttf`/`.otf` from `src/assets/fonts/` into `build/web/assets/fonts/`. Add a `verify_fonts` step that fails the build if any custom font is missing — so this can't silently regress.

The deployed template is unchanged, and no `pyproject.toml` or `theme.py` rewrite is needed.

## Changes

- `portfolio_app/scripts/patch_web_bundle.py` (+59 / -1):
  - New `copy_fonts(web_root)` — iterates `src/assets/fonts/`, copies every `.ttf`/`.otf` into `build/web/assets/fonts/`, idempotent.
  - New `verify_fonts(web_root)` — raises if a custom font is missing from the built site.
  - Both wired into `patch_web_build()`; `verify_web_build()` now also calls `verify_fonts`.
  - `PatchSummary.fonts_copied` field and a print in `main()` so CI logs surface the font count.
- `tests/test_patch_web_bundle.py` (+60 / 0): four new tests covering the copy, idempotence, missing source dir, and verify-failure paths.

## Verification

Local:

```
$ uv run python -m portfolio_app.scripts.patch_web_bundle build/web
Patched .../build/web with 0 runtime files; python-worker.js updated=False;
python.js updated=False; flutter_bootstrap.js updated=False;
7 custom font(s) copied.

$ ls build/web/assets/fonts/
IBMPlexMono-Medium.ttf   MaterialIcons-Regular.otf
IBMPlexMono-Regular.ttf  Poppins-Bold.ttf
IBMPlexMono-SemiBold.ttf Poppins-Medium.ttf
                        Poppins-Regular.ttf
                        Poppins-SemiBold.ttf
                        roboto.woff2
```

Served via `python -m http.server --directory build/web`, all 7 custom font URLs return **200** (previously 404):

```
/assets/fonts/Poppins-Regular.ttf      200
/assets/fonts/Poppins-Bold.ttf         200
/assets/fonts/Poppins-Medium.ttf       200
/assets/fonts/Poppins-SemiBold.ttf     200
/assets/fonts/IBMPlexMono-Regular.ttf  200
/assets/fonts/IBMPlexMono-Medium.ttf   200
/assets/fonts/IBMPlexMono-SemiBold.ttf 200
```

Tests: `uv run pytest` — **25/25 pass** (4 new). `ruff check` and `ruff format --check` clean.

## Not addressed in this PR

The orchestrator comment also flagged the lack of COOP/COEP headers for `crossOriginIsolated` (Pyodide / SharedArrayBuffer). GitHub Pages cannot set those headers, and switching to a Skwasm renderer or a different host would change the deployment surface. Once the fonts are present, the Flet UI renders and Pyodide boots via the JS-compiled path used by `--no-wasm`, which the previous tests on the same site have shown works. I verified Pyodide worker registration locally but did not have a cross-origin-isolated browser context to confirm the SharedArrayBuffer path end-to-end. Recommend opening a follow-up issue to move hosting off GitHub Pages (e.g. Cloudflare Pages with custom headers) if a fully WASM-fast build is needed later.

## Test plan

- [x] `uv run pytest` — 25/25 pass
- [x] `uvx ruff check .` — clean
- [x] `uvx ruff format --check .` — clean
- [x] `python -m portfolio_app.scripts.patch_web_bundle build/web` — reports 7 fonts copied
- [x] HTTP-served `build/web/` returns 200 for all 7 font URLs
- [ ] **Reviewer:** wait for the `Build and Deploy Flet Portfolio` workflow on this branch to deploy the Pages artifact, then visit https://mauricioobgo.github.io/portfolioMauricioobgo/ and confirm the Flet UI renders end-to-end (hero, focus, projects, experience, certifications, contact, fonts visible).
