### PR TITLE
fix(web): revert broken python-worker.js JS unpack hook from PR #42

### DIFF
--- a/portfolio_app/scripts/patch_web_bundle.py
+++ b/portfolio_app/scripts/patch_web_bundle.py
@@ -27,16 +27,14 @@ REQUIRED_BUNDLE_ENTRIES = (
     "six.py",
 )
 
-WORKER_IMPORT_OLD = (
-    "        import flet_js, os, runpy, sys, traceback\n        from pyodide.http import pyfetch\n"
-)
-WORKER_IMPORT_NEW = "        import flet_js, os, runpy, sys, traceback\n"
-WORKER_PY_ARGS_OLD = "        py_args = flet_js.args.to_py() if flet_js.args else None\n"
-WORKER_PY_ARGS_NEW = "        py_args = flet_js.args.to_py() if flet_js.args else {}\n"
-WORKER_HOOK_OLD = (
-    "        flet_js.documentUrl = documentUrl;\n        await self.pyodide.runPythonAsync(`\n"
-)
-WORKER_HOOK_NEW = """        flet_js.documentUrl = documentUrl;
+# Flet's stock python-worker.js has the JS fetch+unpackArchive hook in the
+# top-level ``self.initPyodide`` body. PR #42 used to remove that hook and
+# replace the Python-side archive download with a no-op (relying on the JS
+# side to do the unpack). The JS-side path is broken on Pyodide's MEMFS
+# (``shutil.unpack_archive`` falls over on a JS-supplied ``ArrayBuffer``),
+# so we now keep the stock JS hook and ensure the original Python-side
+# ``pyfetch(...).unpack_archive()`` flow runs.
+WORKER_JS_HOOK_OLD = """        flet_js.documentUrl = documentUrl;
         const pyArgs = self.flet_js.args || {};
         if (!("script" in pyArgs)) {
             const appPackageUrl = new URL(
@@ -53,7 +51,14 @@ WORKER_HOOK_NEW = """        flet_js.documentUrl = documentUrl;
         }
         await self.pyodide.runPythonAsync(`
 """
-WORKER_ARCHIVE_BLOCK_OLD = """        if "script" not in py_args:
+WORKER_JS_HOOK_NEW = "        flet_js.documentUrl = documentUrl;\n        await self.pyodide.runPythonAsync(`\n"
+WORKER_JS_HOOK_MARKER = 'self.pyodide.unpackArchive(archiveBuffer, "zip");'
+WORKER_ARCHIVE_BLOCK_OLD = """        if "script" in py_args:
+            print("Saving script to a file")
+            with open(f"{python_module_name}.py", "w") as f:
+                f.write(py_args["script"]);
+"""
+WORKER_ARCHIVE_BLOCK_NEW = """        if "script" not in py_args:
             print("Downloading app archive")
             response = await pyfetch(app_package_url)
             await response.unpack_archive()
@@ -62,12 +67,6 @@ WORKER_ARCHIVE_BLOCK_OLD = """        if "script" not in py_args:
             with open(f"{python_module_name}.py", "w") as f:
                 f.write(py_args["script"]);
 """
-WORKER_ARCHIVE_BLOCK_NEW = """        if "script" in py_args:
-            print("Saving script to a file")
-            with open(f"{python_module_name}.py", "w") as f:
-                f.write(py_args["script"]);
-"""
-WORKER_PATCH_MARKER = 'self.pyodide.unpackArchive(archiveBuffer, "zip");'
 PYTHON_LOADER_READY_OLD = """    } else {
         console.log(`Python worker initialized: ${appId}`);
     }
@@ -163,25 +162,34 @@ def patch_python_worker(worker_path: Path) -> bool:
     content = worker_path.read_text(encoding="utf-8")
     original = content
 
-    content, _ = _replace_once(content, WORKER_IMPORT_OLD, WORKER_IMPORT_NEW, label="worker import")
-    content, _ = _replace_once(content, WORKER_PY_ARGS_OLD, WORKER_PY_ARGS_NEW, label="worker args")
+    # Drop the JS-side ``fetch + unpackArchive`` block that PR #42 added. The
+    # MEMFS-backed Pyodide that Flet ships cannot seek inside the temp file
+    # produced from a JS ``ArrayBuffer``; the unpack raises EINVAL and the
+    # site stays blank. Restoring the original 2-line ``documentUrl`` /
+    # ``runPythonAsync`` opener lets the Python-side ``pyfetch`` flow below
+    # do the unpacking instead.
+    content, js_hook_changed = _replace_once(
+        content,
+        WORKER_JS_HOOK_OLD,
+        WORKER_JS_HOOK_NEW,
+        label="worker JS archive hook",
+    )
+
+    # Restore the Python-side archive download. PR #42 reduced this branch
+    # to a script-only no-op because it expected the JS hook above to have
+    # already unpacked ``app.zip``. Without the JS hook, ``main.py`` is
+    # never extracted from ``app.zip`` and ``runpy`` fails.
     content, archive_block_changed = _replace_once(
         content,
         WORKER_ARCHIVE_BLOCK_OLD,
         WORKER_ARCHIVE_BLOCK_NEW,
         label="worker archive block",
     )
-    content, hook_changed = _replace_once(
-        content,
-        WORKER_HOOK_OLD,
-        WORKER_HOOK_NEW,
-        label="worker JS archive hook",
-    )
 
     if content != original:
         worker_path.write_text(content, encoding="utf-8")
 
-    return archive_block_changed or hook_changed
+    return js_hook_changed or archive_block_changed
 
 
 def patch_python_loader(loader_path: Path) -> bool:
@@ -308,10 +316,18 @@ def verify_python_worker(worker_path: Path) -> None:
         raise FileNotFoundError(f"Python worker not found: {worker_path}")
 
     content = worker_path.read_text(encoding="utf-8")
-    if "response.unpack_archive()" in content:
-        raise RuntimeError("python-worker.js still uses response.unpack_archive().")
-    if WORKER_PATCH_MARKER not in content:
-        raise RuntimeError("python-worker.js is missing the JS-side app.zip unpack patch.")
+    if WORKER_JS_HOOK_MARKER in content:
+        raise RuntimeError(
+            "python-worker.js still uses the broken JS-side "
+            f"{WORKER_JS_HOOK_MARKER!r} hook. The JS-side unpack path is "
+            "broken on Pyodide's MEMFS and was removed in the PR #42 revert."
+        )
+    if "response.unpack_archive()" not in content:
+        raise RuntimeError(
+            "python-worker.js is missing the Python-side "
+            "`response.unpack_archive()` flow that extracts app.zip. Without "
+            "it, runpy cannot find main.py and the site stays blank."
+        )
 
 
 def verify_python_loader(loader_path: Path) -> None:

--- a/portfolio_app/scripts/patch_web_bundle.py
+++ b/portfolio_app/scripts/patch_web_bundle.py
@@ -51,7 +51,9 @@ WORKER_JS_HOOK_OLD = """        flet_js.documentUrl = documentUrl;
         }
         await self.pyodide.runPythonAsync(`
 """
-WORKER_JS_HOOK_NEW = "        flet_js.documentUrl = documentUrl;\n        await self.pyodide.runPythonAsync(`\n"
+WORKER_JS_HOOK_NEW = (
+    "        flet_js.documentUrl = documentUrl;\n        await self.pyodide.runPythonAsync(`\n"
+)
 WORKER_JS_HOOK_MARKER = 'self.pyodide.unpackArchive(archiveBuffer, "zip");'
 WORKER_ARCHIVE_BLOCK_OLD = """        if "script" in py_args:
             print("Saving script to a file")

--- a/tests/test_patch_web_bundle.py
+++ b/tests/test_patch_web_bundle.py
@@ -130,7 +130,7 @@ def test_patch_web_build_updates_worker_and_verifies_artifact(tmp_path, monkeypa
 
     _write_bundle(bundle_path, {"main.py": "print('app')\n"})
     worker_path.parent.mkdir(parents=True, exist_ok=True)
-    worker_path.write_text(_read_worker_fixture(), encoding="utf-8")
+    worker_path.write_text(_read_worker_fixture_broken(), encoding="utf-8")
     loader_path.write_text(
         "    } else {\n        console.log(`Python worker initialized: ${appId}`);\n    }\n",
         encoding="utf-8",
@@ -154,8 +154,12 @@ def test_patch_web_build_updates_worker_and_verifies_artifact(tmp_path, monkeypa
     assert summary.bootstrap_patched is True
 
     worker_content = worker_path.read_text(encoding="utf-8")
-    assert 'self.pyodide.unpackArchive(archiveBuffer, "zip");' in worker_content
-    assert "response.unpack_archive()" not in worker_content
+    # The JS-side hook from PR #42 should be gone — it raises EINVAL on
+    # Pyodide's MEMFS-backed file and keeps the site blank.
+    assert 'self.pyodide.unpackArchive(archiveBuffer, "zip");' not in worker_content
+    # The original Python-side unpack flow must be back so main.py is found.
+    assert "response.unpack_archive()" in worker_content
+    assert "from pyodide.http import pyfetch" in worker_content
 
     loader_content = loader_path.read_text(encoding="utf-8")
     assert "globalThis.removeSplashFromWeb();" in loader_content
@@ -170,7 +174,143 @@ def test_patch_web_build_updates_worker_and_verifies_artifact(tmp_path, monkeypa
     assert set(patch_web_bundle.REQUIRED_BUNDLE_ENTRIES) <= names
 
 
+def _read_worker_fixture_broken() -> str:
+    """Mirror of the PR #42 patched python-worker.js (with the broken JS hook)."""
+    return """self.pyodideUrl = null;
+self.appPackageUrl = null;
+self.micropipIncludePre = false;
+self.pythonModuleName = null;
+self.documentUrl = null;
+self.initialized = false;
+self.flet_js = {}; // namespace for Python global functions
+
+self.initPyodide = async function () {
+    try {
+        importScripts(self.pyodideUrl);
+        self.pyodide = await loadPyodide();
+        self.pyodide.registerJsModule("flet_js", flet_js);
+        self.pyodide.globals.set("app_package_url", self.appPackageUrl);
+        self.pyodide.globals.set("python_module_name", self.pythonModuleName);
+        self.pyodide.globals.set("micropip_include_pre", self.micropipIncludePre);
+        flet_js.documentUrl = documentUrl;
+        const pyArgs = self.flet_js.args || {};
+        if (!("script" in pyArgs)) {
+            const appPackageUrl = new URL(
+                pyArgs["app_package_url"] || self.appPackageUrl || "assets/app/app.zip",
+                self.documentUrl || self.location.href
+            ).toString();
+            console.log("Downloading app archive");
+            const archiveResponse = await fetch(appPackageUrl);
+            if (!archiveResponse.ok) {
+                throw new Error(`Unable to fetch app archive: ${archiveResponse.status} ${archiveResponse.statusText}`);
+            }
+            const archiveBuffer = await archiveResponse.arrayBuffer();
+            self.pyodide.unpackArchive(archiveBuffer, "zip");
+        }
+        await self.pyodide.runPythonAsync(`
+        import flet_js, os, runpy, sys, traceback
+        from pyodide.http import pyfetch
+
+        py_args = flet_js.args.to_py() if flet_js.args else {}
+
+        if "app_package_url" in py_args:
+            app_package_url = py_args["app_package_url"]
+
+        if app_package_url is None:
+            app_package_url = "assets/app/app.zip"
+
+        if "python_module_name" in py_args:
+            python_module_name = py_args["python_module_name"]
+
+        if python_module_name is None:
+            python_module_name = "main"
+
+        if "micropip_include_pre" in py_args:
+            micropip_include_pre = py_args["micropip_include_pre"]
+
+        if micropip_include_pre is None:
+            micropip_include_pre = False
+
+        print("python_module_name:", python_module_name)
+        print("micropip_include_pre:", micropip_include_pre)
+
+        if "script" in py_args:
+            print("Saving script to a file")
+            with open(f"{python_module_name}.py", "w") as f:
+                f.write(py_args["script"]);
+
+        pkgs_path = "__pypackages__"
+        if os.path.exists(pkgs_path):
+            print(f"Adding {pkgs_path} to sys.path")
+            sys.path.insert(0, pkgs_path)
+
+        async def ensure_micropip():
+            try:
+                import micropip
+            except ImportError:
+                import pyodide_js
+                await pyodide_js.loadPackage("micropip")
+                import micropip
+            return micropip
+
+        if os.path.exists("requirements.txt"):
+            with open("requirements.txt", "r") as f:
+                deps = []
+
+        if "dependencies" in py_args:
+            micropip = await ensure_micropip()
+            await micropip.install(py_args["dependencies"], pre=micropip_include_pre)
+
+        runpy.run_module(python_module_name, run_name="__main__")
+      `);
+        await self.flet_js.start_connection(self.receiveCallback);
+        self.postMessage("initialized");
+    } catch (error) {
+        self.postMessage(error.toString());
+    }
+};
+"""
+
+
 def test_verify_web_build_rejects_wasm_bootstrap(tmp_path) -> None:
+    web_root = tmp_path / "build" / "web"
+    bundle_path = web_root / "assets" / "app" / "app.zip"
+    worker_path = web_root / "python-worker.js"
+    loader_path = web_root / "python.js"
+    bootstrap_path = web_root / "flutter_bootstrap.js"
+
+    _write_bundle(
+        bundle_path,
+        {
+            "main.py": "print('app')\n",
+            "flet/__init__.py": "__all__ = []\n",
+            "flet_lottie/__init__.py": "__all__ = []\n",
+            "msgpack/__init__.py": "__all__ = []\n",
+            "repath.py": "def parse(path):\n    return path\n",
+            "six.py": "__version__ = '1.17.0'\n",
+        },
+    )
+    worker_path.parent.mkdir(parents=True, exist_ok=True)
+    worker_path.write_text(
+        # Stock Flet worker, post-patch (no JS-side unpack hook).
+        "        await self.pyodide.runPythonAsync(`\n"
+        "        response = await pyfetch(app_package_url)\n"
+        "        await response.unpack_archive()\n"
+        "`);\n",
+        encoding="utf-8",
+    )
+    loader_path.write_text("globalThis.removeSplashFromWeb();\n", encoding="utf-8")
+    bootstrap_path.write_text(
+        '_flutter.buildConfig = {"builds":[{"compileTarget":"dart2wasm","renderer":"skwasm","mainWasmPath":"main.dart.wasm"}]};\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="WASM startup path"):
+        patch_web_bundle.verify_web_build(web_root)
+
+
+def test_verify_web_build_rejects_broken_js_hook(tmp_path) -> None:
+    """If the PR #42 JS-side unpackArchive hook is present, verify raises."""
     web_root = tmp_path / "build" / "web"
     bundle_path = web_root / "assets" / "app" / "app.zip"
     worker_path = web_root / "python-worker.js"
@@ -196,11 +336,11 @@ def test_verify_web_build_rejects_wasm_bootstrap(tmp_path) -> None:
     )
     loader_path.write_text("globalThis.removeSplashFromWeb();\n", encoding="utf-8")
     bootstrap_path.write_text(
-        '_flutter.buildConfig = {"builds":[{"compileTarget":"dart2wasm","renderer":"skwasm","mainWasmPath":"main.dart.wasm"}]};\n',
+        '_flutter.buildConfig = {"builds":[{"compileTarget":"dart2js","mainJsPath":"main.dart.js"}]};\n',
         encoding="utf-8",
     )
 
-    with pytest.raises(RuntimeError, match="WASM startup path"):
+    with pytest.raises(RuntimeError, match="JS-side"):
         patch_web_bundle.verify_web_build(web_root)
 
 


### PR DESCRIPTION
## Summary

PR #42 (commit `2748dac`) tried to fix the blank GitHub Pages site but introduced a new blank-state bug. The Python worker now hangs on init with `OSError: [Errno 28] Invalid argument` inside `shutil.unpack_archive()`, the canvas never gets created, and the site is still blank.

This PR reverts the over-aggressive worker patch and keeps the font fix.

## Root cause

PR #42 added a `WORKER_HOOK_NEW` block in `portfolio_app/scripts/patch_web_bundle.py` that, in `python-worker.js`, did:

```js
const archiveResponse = await fetch(appPackageUrl);
const archiveBuffer = await archiveResponse.arrayBuffer();
self.pyodide.unpackArchive(archiveBuffer, "zip");
```

`self.pyodide.unpackArchive(buffer, "zip")` writes the `ArrayBuffer` to a MEMFS temp file and then calls `shutil.unpack_archive` on it. Inside `zipfile.ZipFile.open()`, the read path hits `self._file.seek(self._pos)` and the MEMFS-backed file rejects the seek with `EINVAL` ([Errno 28]). The unpack fails, `main.py` is never extracted from `app.zip`, `runpy` cannot find it, and the worker init blows up. The MaterialIcons font warning users see in the console is a downstream symptom of the worker never reaching the post-init state where Flutter registers the font.

## Fix

- Drop the JS-side `fetch + unpackArchive` hook from the generated `python-worker.js`.
- Restore the original Python-side `pyfetch(app_package_url).unpack_archive()` flow, which uses `pyodide.http` and works correctly on MEMFS.
- Rewrite the `WORKER_*` constants in `patch_web_bundle.py` so the JS hook has a single, clearly-named `WORKER_JS_HOOK` pair, and the archive block's `NEW` form is the original Python flow.
- Update `verify_python_worker` to check both: the JS hook is **gone** AND the Python `response.unpack_archive()` flow is **back**.
- Add a new test (`test_verify_web_build_rejects_broken_js_hook`) so the broken state is caught by CI if it ever sneaks back in.
- Update the existing `test_patch_web_build_updates_worker_and_verifies_artifact` to seed the post-PR-42 broken worker and assert the patch produces the working form.
- Keep the font fix from PR #42 — `copy_fonts` and `verify_fonts` are still doing the right thing for the 7 Poppins/IBMPlexMono fonts.

## Verification

- [x] `build/web/python-worker.js` no longer contains `self.pyodide.unpackArchive(archiveBuffer, "zip")` (verified by running `python -m portfolio_app.scripts.patch_web_build build/web` against the existing built site — the JS hook was stripped and the Python `pyfetch(...).unpack_archive()` flow was restored)
- [x] `verify_web_build` passes against the rebuilt site
- [x] All 26 tests pass (`uv run pytest -q`): 7 in `tests/test_patch_web_bundle.py` (1 new), 19 in the rest of the suite
- [x] `ruff check` is clean on both touched files
- [x] PR #42's font fix is preserved: `copy_fonts` still runs, `verify_fonts` still runs, all 7 custom fonts land in `build/web/assets/fonts/`
- [ ] Browser smoke test against https://mauricioobgo.github.io/portfolioMauricioobgo/ — needs the merged site to be redeployed, leaving for the maintainer

## Test plan

1. Pull this branch and run `uv sync && uv run flet build web src --module-name main --yes --base-url /portfolioMauricioobgo/ --route-url-strategy hash --no-wasm`.
2. Inspect `build/web/python-worker.js` — it should have the simple 2-line opener `flet_js.documentUrl = documentUrl; await self.pyodide.runPythonAsync(\``...` with the original Python `pyfetch(...).unpack_archive()` flow inside the Python body. **No** `self.pyodide.unpackArchive(archiveBuffer, "zip")`.
3. Serve `build/web` locally and load the site — the Flet portfolio UI should render and the MaterialIcons font warning should be gone.
4. `uv run pytest -q` — all 26 tests pass.

## Constraints honored

- Kept PR #42's font fix (`copy_fonts`, `verify_fonts`, `FONTS_RELATIVE_PATH`, `SOURCE_FONTS_DIR`) — only the worker patch is reverted.
- Did not touch the Python/Flet stack.
- Did not break the existing test suite (26/26 pass).
- Did not merge — opening for review.
