### PR TITLE
Improve Pac-Man overlay and terminal shell

### DIFF
--- a/src/portfolio/components/assistant.py
+++ b/src/portfolio/components/assistant.py
@@ -153,6 +153,7 @@ def _execute_terminal_command(
     head = parts[0].lower() if parts else ""
     arg = " ".join(parts[1:])
     profile = content.get("profile", {})
+    profile_links = profile.get("links", {})
     projects = content.get("featured_projects", [])
     certifications = content.get("certifications", [])
     stack = content.get("technical_stack", [])
@@ -178,7 +179,8 @@ def _execute_terminal_command(
             "  stack               tooling i reach for",
             "  ai                  llm / agent work",
             "  github              github profile + repos",
-            "  resume / cv         open the resume",
+            "  resume / cv         open the resume link",
+            "  open <target>       github | linkedin | resume",
             "  date                current date",
             "  echo <text>         echo arguments",
             "  history             command history",
@@ -206,8 +208,8 @@ def _execute_terminal_command(
             "BEGIN:VCARD",
             f"FN:{profile.get('name', 'Mauricio Obando')}",
             f"EMAIL:{profile.get('email', 'mauricioobgo@gmail.com')}",
-            f"URL:{profile.get('linkedin_url', profile.get('linkedin', ''))}",
-            f"URL:{profile.get('github_url', github.get('profile', {}).get('html_url', ''))}",
+            f"URL:{profile.get('linkedin_url', profile_links.get('linkedin', profile.get('linkedin', '')))}",
+            f"URL:{profile.get('github_url', profile_links.get('github', github.get('profile', {}).get('html_url', '')))}",
             "END:VCARD",
         ], None
     if head == "cat":
@@ -256,11 +258,34 @@ def _execute_terminal_command(
             f"public repos: {summary.get('repo_count', 0)}",
         ], None
     if head in {"resume", "cv"}:
-        return [profile.get("resume_link", "Resume link unavailable.")], None
+        resume_link = profile.get("resume_link", "")
+        if resume_link:
+            return [f"opening resume: {resume_link}"], f"open:{resume_link}"
+        return ["Resume link unavailable."], None
+    if head == "open":
+        targets = {
+            "github": profile.get(
+                "github_url",
+                profile_links.get("github", github.get("profile", {}).get("html_url", "")),
+            ),
+            "linkedin": profile.get(
+                "linkedin_url", profile_links.get("linkedin", profile.get("linkedin", ""))
+            ),
+            "resume": profile.get("resume_link", ""),
+            "cv": profile.get("resume_link", ""),
+        }
+        target = arg.lower()
+        url = targets.get(target, arg if arg.startswith(("https://", "http://")) else "")
+        if url:
+            return [f"opening {target or 'url'}: {url}"], f"open:{url}"
+        return ["open: expected github, linkedin, resume, or https:// URL"], None
     if head == "contact":
         return [
             profile.get("email", "mauricioobgo@gmail.com"),
-            profile.get("github_url", "https://github.com/mauricioobgo"),
+            profile.get(
+                "github_url", profile_links.get("github", "https://github.com/mauricioobgo")
+            ),
+            profile.get("linkedin_url", profile_links.get("linkedin", profile.get("linkedin", ""))),
         ], None
     if head == "experience":
         return _latest_role_lines(content), None
@@ -289,13 +314,46 @@ def _execute_terminal_command(
 
 
 def _terminal_line(text: str, role: str) -> ft.Control:
+    if not text:
+        return ft.Container(height=6)
     prefixes = {"system": "#", "assistant": ">", "user": "$"}
     colors = {"system": SECONDARY, "assistant": TEXT, "user": PRIMARY}
-    return ft.Text(
-        f"{prefixes.get(role, '>')} {text}",
-        color=colors.get(role, TEXT),
-        size=13,
-        font_family="Mono",
+    accent = colors.get(role, TEXT)
+    return ft.Container(
+        padding=ft.Padding.symmetric(horizontal=10, vertical=6),
+        border_radius=10,
+        bgcolor=alpha(accent, 0.055 if role != "user" else 0.09),
+        content=ft.Row(
+            spacing=8,
+            vertical_alignment=ft.CrossAxisAlignment.START,
+            controls=[
+                ft.Text(
+                    prefixes.get(role, ">"),
+                    color=accent,
+                    size=13,
+                    font_family="Mono",
+                    weight=ft.FontWeight.W_700,
+                ),
+                ft.Text(
+                    text,
+                    color=colors.get(role, TEXT),
+                    size=13,
+                    font_family="Mono",
+                    selectable=True,
+                    expand=True,
+                ),
+            ],
+        ),
+    )
+
+
+def _terminal_chip(label: str, color: str) -> ft.Control:
+    return ft.Container(
+        padding=ft.Padding.symmetric(horizontal=10, vertical=5),
+        border_radius=999,
+        bgcolor=alpha(color, 0.11),
+        border=ft.Border.all(1, alpha(color, 0.28)),
+        content=ft.Text(label, color=color, size=11, font_family="Mono"),
     )
 
 
@@ -328,14 +386,70 @@ class PortfolioTerminalShell(ft.Container):
         return 440
 
     def _build(self) -> ft.Control:
+        quick_commands = ["help", "projects", "stack", "github", "resume"]
+        input_bar = ft.Container(
+            padding=ft.Padding.symmetric(horizontal=12, vertical=4),
+            border_radius=14,
+            bgcolor=alpha("#020617", 0.78),
+            border=ft.Border.all(1, alpha(PRIMARY, 0.22)),
+            content=ft.Row(
+                spacing=10,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                controls=[
+                    ft.Text(
+                        "mauricio@cloud",
+                        color=SECONDARY,
+                        size=13,
+                        font_family="Mono",
+                        weight=ft.FontWeight.W_700,
+                    ),
+                    ft.Text(":~$", color=PRIMARY, size=13, font_family="Mono"),
+                    ft.TextField(
+                        ref=self._input_ref,
+                        expand=True,
+                        hint_text="Try help, projects redshift, open github, matrix...",
+                        filled=False,
+                        border=ft.InputBorder.NONE,
+                        color=TEXT,
+                        cursor_color=PRIMARY,
+                        hint_style=ft.TextStyle(color=MUTED, size=13),
+                        text_style=ft.TextStyle(color=TEXT, size=14, font_family="Mono"),
+                        on_submit=self._handle_submit,
+                        autofocus=True,
+                    ),
+                ],
+            ),
+        )
         terminal_body = ft.Container(
             border_radius=20,
-            border=ft.Border.all(1, alpha(PRIMARY, 0.18)),
-            bgcolor=alpha("#08111E", 0.88),
+            border=ft.Border.all(1, alpha(PRIMARY, 0.22)),
+            bgcolor=alpha("#08111E", 0.92),
             padding=ft.Padding.all(18),
             content=ft.Column(
                 spacing=14,
                 controls=[
+                    ft.Row(
+                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                        wrap=True,
+                        controls=[
+                            ft.Row(
+                                spacing=8,
+                                wrap=True,
+                                controls=[
+                                    _terminal_chip("STATIC-SAFE", SECONDARY),
+                                    _terminal_chip("LOCAL CONTEXT", PRIMARY),
+                                    _terminal_chip("NO API KEY", WARNING),
+                                ],
+                            ),
+                            ft.Text(
+                                "enter runs command • links open in a new tab",
+                                color=MUTED,
+                                size=12,
+                                font_family="Mono",
+                            ),
+                        ],
+                    ),
                     ft.ListView(
                         ref=self._log_ref,
                         height=self._log_height(),
@@ -348,40 +462,24 @@ class PortfolioTerminalShell(ft.Container):
                         visible=False,
                         spacing=4,
                         controls=[
+                            ft.ProgressRing(width=14, height=14, stroke_width=2, color=PRIMARY),
                             ft.Text("working", color=PRIMARY, size=13, font_family="Mono"),
-                            ft.Text(".", color=PRIMARY, size=13, font_family="Mono"),
-                            ft.Text(".", color=PRIMARY, size=13, font_family="Mono"),
-                            ft.Text(".", color=PRIMARY, size=13, font_family="Mono"),
                         ],
                     ),
                     ft.Row(
-                        spacing=10,
-                        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                        spacing=8,
+                        wrap=True,
                         controls=[
-                            ft.Text(
-                                "mauricio@cloud",
-                                color=SECONDARY,
-                                size=13,
-                                font_family="Mono",
-                            ),
-                            ft.Text(":", color=MUTED, size=13, font_family="Mono"),
-                            ft.Text("~", color=PRIMARY, size=13, font_family="Mono"),
-                            ft.Text("$", color=TEXT, size=13, font_family="Mono"),
-                            ft.TextField(
-                                ref=self._input_ref,
-                                expand=True,
-                                hint_text="Try whoami, ls, cat about.md, projects, or matrix",
-                                filled=False,
-                                border=ft.InputBorder.NONE,
-                                color=TEXT,
-                                cursor_color=PRIMARY,
-                                hint_style=ft.TextStyle(color=MUTED, size=13),
-                                text_style=ft.TextStyle(color=TEXT, size=14, font_family="Mono"),
-                                on_submit=self._handle_submit,
-                                autofocus=True,
-                            ),
+                            ft.TextButton(
+                                content=command,
+                                icon=ft.Icons.TERMINAL,
+                                style=ft.ButtonStyle(color=PRIMARY),
+                                on_click=lambda _, value=command: self._submit_command(value),
+                            )
+                            for command in quick_commands
                         ],
                     ),
+                    input_bar,
                 ],
             ),
         )
@@ -389,13 +487,14 @@ class PortfolioTerminalShell(ft.Container):
             ref=self._matrix_ref,
             visible=False,
             border_radius=20,
-            bgcolor=alpha("#03140B", 0.84),
+            bgcolor=alpha("#03140B", 0.88),
             padding=ft.Padding.all(24),
             content=ft.Column(
                 alignment=ft.MainAxisAlignment.CENTER,
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
                 spacing=8,
                 controls=[
+                    ft.Icon(ft.Icons.CODE, color=SECONDARY, size=42),
                     ft.Text(
                         "Wake up, Neo ...",
                         color=SECONDARY,
@@ -424,7 +523,7 @@ class PortfolioTerminalShell(ft.Container):
                         wrap=True,
                         controls=[
                             ft.Text(
-                                "Terminal ready. AI cards route prompt text here.",
+                                "Terminal ready. Quick commands, AI cards, and shell input share one router.",
                                 ref=self._status_ref,
                                 color=MUTED,
                                 size=12,
@@ -434,6 +533,7 @@ class PortfolioTerminalShell(ft.Container):
                                 color=PRIMARY,
                                 size=12,
                                 font_family="Mono",
+                                selectable=True,
                             ),
                         ],
                     ),
@@ -469,6 +569,16 @@ class PortfolioTerminalShell(ft.Container):
             self._log_ref.current.controls = []
             self._log_ref.current.update()
 
+    def _submit_command(self, command: str) -> None:
+        question = command.strip()
+        if not question or self._busy:
+            return
+        if self._input_ref.current:
+            self._input_ref.current.value = ""
+            self._input_ref.current.update()
+        if self.page:
+            self.page.run_task(self._emit_response, question)
+
     def _handle_submit(self, event: ft.ControlEvent) -> None:
         question = (event.control.value or "").strip()
         if not question or self._busy:
@@ -476,8 +586,7 @@ class PortfolioTerminalShell(ft.Container):
 
         event.control.value = ""
         event.control.update()
-        if self.page:
-            self.page.run_task(self._emit_response, question)
+        self._submit_command(question)
 
     async def _emit_response(self, question: str) -> None:
         self._busy = True
@@ -509,6 +618,8 @@ class PortfolioTerminalShell(ft.Container):
             await asyncio.sleep(1.8)
             self._matrix_ref.current.visible = False
             self._matrix_ref.current.update()
+        elif action and action.startswith("open:") and self.page:
+            self.page.launch_url(action.removeprefix("open:"))
 
         if self._status_ref.current:
             self._status_ref.current.value = "Response emitted from local portfolio context."

--- a/src/portfolio/components/mascots.py
+++ b/src/portfolio/components/mascots.py
@@ -27,6 +27,9 @@ class PacmanBorderOverlay(ft.Container):
         self._runner_ref = ft.Ref[ft.Container]()
         self._mouth_ref = ft.Ref[ft.Container]()
         self._eye_ref = ft.Ref[ft.Container]()
+        self._pellet_refs: list[ft.Ref[ft.Container]] = []
+        self._pellet_distances: list[float] = []
+        self._last_eaten_count = -1
         self._direction = "east"
         self._width = 0
         self._height = 0
@@ -73,8 +76,8 @@ class PacmanBorderOverlay(ft.Container):
             "spacing": round(38 * scale),
             "dot": 5 * scale,
             "power": 9 * scale,
-            "pac": 24 * scale,
-            "glow": 36 * scale,
+            "pac": 26 * scale,
+            "glow": 40 * scale,
         }
 
     def _rebuild(self) -> None:
@@ -83,6 +86,9 @@ class PacmanBorderOverlay(ft.Container):
         metrics = self._metrics()
         controls: list[ft.Control] = []
         inset = metrics["inset"]
+        self._pellet_refs = []
+        self._pellet_distances = []
+        self._last_eaten_count = -1
 
         controls.extend(
             [
@@ -119,17 +125,22 @@ class PacmanBorderOverlay(ft.Container):
 
         points = self._perimeter_points(metrics)
         power_indexes = {0, len(points) // 4, len(points) // 2, (len(points) * 3) // 4}
-        for index, (x, y) in enumerate(points):
+        for index, (x, y, distance) in enumerate(points):
             power = index in power_indexes
             size = metrics["power"] if power else metrics["dot"]
+            pellet_ref = ft.Ref[ft.Container]()
+            self._pellet_refs.append(pellet_ref)
+            self._pellet_distances.append(distance)
             controls.append(
                 ft.Container(
+                    ref=pellet_ref,
                     left=x - size / 2,
                     top=y - size / 2,
                     width=size,
                     height=size,
                     border_radius=999,
                     bgcolor=alpha(WARNING, 0.9 if power else 0.72),
+                    animate_opacity=ft.Animation(120, ft.AnimationCurve.EASE_OUT),
                     shadow=(
                         [ft.BoxShadow(blur_radius=14, color=alpha(WARNING, 0.22))]
                         if power
@@ -138,48 +149,53 @@ class PacmanBorderOverlay(ft.Container):
                 )
             )
 
+        pac = metrics["pac"]
+        mouth = max(9, pac * 0.64)
+        eye = max(3.5, pac * 0.16)
         controls.append(
             ft.Container(
                 ref=self._runner_ref,
-                width=metrics["pac"],
-                height=metrics["pac"],
-                animate_position=ft.Animation(260, ft.AnimationCurve.LINEAR),
+                width=pac,
+                height=pac,
+                animate_position=ft.Animation(150, ft.AnimationCurve.LINEAR),
+                animate_rotation=ft.Animation(120, ft.AnimationCurve.LINEAR),
                 content=ft.Stack(
-                    width=metrics["pac"],
-                    height=metrics["pac"],
+                    width=pac,
+                    height=pac,
+                    clip_behavior=ft.ClipBehavior.NONE,
                     controls=[
                         ft.Container(
                             width=metrics["glow"],
                             height=metrics["glow"],
-                            left=-(metrics["glow"] - metrics["pac"]) / 2,
-                            top=-(metrics["glow"] - metrics["pac"]) / 2,
+                            left=-(metrics["glow"] - pac) / 2,
+                            top=-(metrics["glow"] - pac) / 2,
                             border_radius=999,
                             bgcolor=alpha(WARNING, 0.14),
                         ),
                         ft.Container(
-                            width=metrics["pac"],
-                            height=metrics["pac"],
+                            width=pac,
+                            height=pac,
                             bgcolor=WARNING,
                             border_radius=999,
                             shadow=[ft.BoxShadow(blur_radius=22, color=alpha(WARNING, 0.28))],
                         ),
                         ft.Container(
                             ref=self._eye_ref,
-                            left=8,
-                            top=6,
-                            width=4,
-                            height=4,
+                            left=pac * 0.56,
+                            top=pac * 0.22,
+                            width=eye,
+                            height=eye,
                             bgcolor=BACKGROUND,
                             border_radius=999,
                         ),
                         ft.Container(
                             ref=self._mouth_ref,
-                            right=-1,
-                            top=7,
-                            width=10,
-                            height=11,
+                            left=pac * 0.66,
+                            top=(pac - mouth) / 2,
+                            width=mouth,
+                            height=mouth,
+                            rotate=ft.Rotate(0.7853981634),
                             bgcolor=BACKGROUND,
-                            border_radius=999,
                         ),
                     ],
                 ),
@@ -189,30 +205,30 @@ class PacmanBorderOverlay(ft.Container):
         if self.parent is not None:
             self._stack_ref.current.update()
 
-    def _perimeter_points(self, metrics: dict[str, float]) -> list[tuple[float, float]]:
+    def _perimeter_points(self, metrics: dict[str, float]) -> list[tuple[float, float, float]]:
         inset = metrics["inset"]
         spacing = metrics["spacing"]
         width = self._width - inset * 2
         height = self._height - inset * 2
-        points: list[tuple[float, float]] = []
+        perimeter = max(1, (width * 2) + (height * 2))
+        count = max(24, int(perimeter // spacing))
+        step = perimeter / count
+        return [
+            self._point_at_distance(index * step, width, height, inset) for index in range(count)
+        ]
 
-        top_count = max(8, int(width // spacing))
-        side_count = max(8, int(height // spacing))
-        step_x = width / top_count
-        step_y = height / side_count
-
-        points.extend((inset + step_x * index, inset) for index in range(1, top_count))
-        points.extend(
-            (self._width - inset, inset + step_y * index) for index in range(1, side_count)
-        )
-        points.extend(
-            (self._width - inset - step_x * index, self._height - inset)
-            for index in range(1, top_count)
-        )
-        points.extend(
-            (inset, self._height - inset - step_y * index) for index in range(1, side_count)
-        )
-        return points
+    def _point_at_distance(
+        self, distance: float, width: float, height: float, inset: float
+    ) -> tuple[float, float, float]:
+        perimeter = (width * 2) + (height * 2)
+        distance = distance % perimeter
+        if distance <= width:
+            return inset + distance, inset, distance
+        if distance <= width + height:
+            return self._width - inset, inset + (distance - width), distance
+        if distance <= (width * 2) + height:
+            return self._width - inset - (distance - width - height), self._height - inset, distance
+        return inset, self._height - inset - (distance - (width * 2) - height), distance
 
     def _position_runner(self, progress: float) -> None:
         if not self._runner_ref.current:
@@ -223,82 +239,72 @@ class PacmanBorderOverlay(ft.Container):
         height = self._height - inset * 2
         perimeter = (width * 2) + (height * 2)
         distance = perimeter * progress
+        x, y, _ = self._point_at_distance(distance, width, height, inset)
         pac_half = metrics["pac"] / 2
 
         if distance <= width:
-            x = inset + distance
-            y = inset
             direction = "east"
         elif distance <= width + height:
-            x = self._width - inset
-            y = inset + (distance - width)
             direction = "south"
         elif distance <= (width * 2) + height:
-            x = self._width - inset - (distance - width - height)
-            y = self._height - inset
             direction = "west"
         else:
-            x = inset
-            y = self._height - inset - (distance - (width * 2) - height)
             direction = "north"
 
         runner = self._runner_ref.current
         runner.left = x - pac_half
         runner.top = y - pac_half
-        if self.parent is not None:
-            runner.update()
         self._direction = direction
         self._apply_direction()
+        self._sync_pellets(distance)
+        if self.parent is not None:
+            runner.update()
+
+    def _sync_pellets(self, distance: float) -> None:
+        eaten_count = sum(
+            1 for pellet_distance in self._pellet_distances if pellet_distance < distance
+        )
+        if eaten_count == self._last_eaten_count:
+            return
+        self._last_eaten_count = eaten_count
+        for index, pellet_ref in enumerate(self._pellet_refs):
+            pellet = pellet_ref.current
+            if not pellet:
+                continue
+            pellet.opacity = 0.16 if index < eaten_count else 1
+            if self.parent is not None:
+                pellet.update()
 
     def _apply_direction(self) -> None:
-        mouth = self._mouth_ref.current
-        eye = self._eye_ref.current
-        if not mouth or not eye:
+        runner = self._runner_ref.current
+        if not runner:
             return
-
-        mouth.left = None
-        mouth.right = None
-        mouth.top = None
-        mouth.bottom = None
-
-        if self._direction == "east":
-            eye.left, eye.top = 8, 6
-            mouth.right, mouth.top = -1, 7
-            mouth.width, mouth.height = 10, 11
-        elif self._direction == "west":
-            eye.left, eye.top = 12, 6
-            mouth.left, mouth.top = -1, 7
-            mouth.width, mouth.height = 10, 11
-        elif self._direction == "south":
-            eye.left, eye.top = 12, 8
-            mouth.left, mouth.bottom = 7, -1
-            mouth.width, mouth.height = 11, 10
-        else:
-            eye.left, eye.top = 12, 12
-            mouth.left, mouth.top = 7, -1
-            mouth.width, mouth.height = 11, 10
-        if self.parent is not None:
-            eye.update()
-            mouth.update()
+        rotations = {
+            "east": 0,
+            "south": 1.5707963268,
+            "west": 3.1415926536,
+            "north": -1.5707963268,
+        }
+        runner.rotate = ft.Rotate(rotations.get(self._direction, 0))
 
     async def _animate_chomp(self) -> None:
-        open_close = [(10, 11), (3, 4), (8, 9), (4, 5)]
+        openness = (0.68, 0.2, 0.52, 0.28)
         while self._running:
             mouth = self._mouth_ref.current
             if not mouth:
                 await asyncio.sleep(0.1)
                 continue
-            for width, height in open_close:
+            pac = self._metrics()["pac"]
+            for factor in openness:
                 if not self._running or not self._mouth_ref.current:
                     return
-                if self._direction in {"east", "west"}:
-                    mouth.width = width
-                    mouth.height = max(height, 9)
-                else:
-                    mouth.height = width
-                    mouth.width = max(height, 9)
+                size = max(5, pac * factor)
+                mouth.width = size
+                mouth.height = size
+                mouth.left = pac * (0.74 if factor < 0.3 else 0.66)
+                mouth.top = (pac - size) / 2
                 mouth.update()
-                await asyncio.sleep(0.12)
+                await asyncio.sleep(0.11)
 
 
 class RetroDroidRunway(ft.Container):


### PR DESCRIPTION
### Motivation
- The Pac-Man border overlay and the browser CLI needed more accurate motion/animation and clearer terminal UX: the runner, mouth animation, and pellet behavior were visually inconsistent and the CLI lacked quick commands, selectable output, and link handling.

### Description
- Reworked the Pac-Man overlay in `src/portfolio/components/mascots.py` to compute a full perimeter path, track pellet positions, dim pellets as they are passed, rotate the runner by travel direction, and animate a wedge-style chomp for more natural motion and timing adjustments.
- Redesigned terminal UI in `src/portfolio/components/assistant.py` to use selectable, row-styled output, soft role-based row backgrounds, status chips, quick-command buttons, and a framed prompt bar with a `_submit_command` helper to unify typed and button-driven commands.
- Added `open <target>` and enhanced `resume` handling so terminal commands can return an `open:` action and the shell will launch the URL in the browser, and improved contact/vCard output to use robust social-link fallbacks.
- Kept behavior backwards-compatible with existing terminal routing and prefill mechanics while tuning animation timing and layout metrics for desktop/tablet breakpoints.

### Testing
- Ran code formatting and static checks with `uv run ruff format ...` and `uv run ruff check .`, which completed successfully.
- Executed unit tests with `uv run pytest -q`, which passed (`27 passed`).
- Ran the content generation script `uv run python -m portfolio_app.scripts.build_content`, which completed successfully in the environment.
- Attempted a production web build (`uv run flet build web --yes`) and a local web run (`uv run flet run --web`), but those failed because the environment blocked required downloads (Flutter / `flet-web`), so a live web build/runtime could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a294f67715c8330bf4614577d2feff6)