### PR TITLE
Auto-clear stale Flutter service worker on the static site

### DIFF
--- a/portfolio_app/scripts/build_static_site.py
+++ b/portfolio_app/scripts/build_static_site.py
@@ -475,6 +475,7 @@ def render_html(content: dict[str, Any]) -> str:
 <meta property="og:title" content="{title}">
 <meta property="og:description" content="{desc}">
 <meta property="og:type" content="website">
+<script>{SW_RESET}</script>
 <style>{CSS}</style>
 </head>
 <body>
@@ -483,6 +484,22 @@ def render_html(content: dict[str, Any]) -> str:
 </body>
 </html>"""
 
+
+# Earlier Flet/Flutter deploys registered a service worker at this path scope
+# that aggressively caches and would keep serving the old (broken) bundle. This
+# unregisters it, clears its caches, and reloads once so returning visitors get
+# the static site without manually clearing site data.
+SW_RESET = """
+(function(){
+  if(!('serviceWorker' in navigator))return;
+  navigator.serviceWorker.getRegistrations().then(function(regs){
+    var had=regs.length>0;
+    regs.forEach(function(r){r.unregister();});
+    if(window.caches&&caches.keys){caches.keys().then(function(ks){ks.forEach(function(k){caches.delete(k);});});}
+    if(had&&!sessionStorage.getItem('swCleared')){sessionStorage.setItem('swCleared','1');location.reload();}
+  }).catch(function(){});
+})();
+"""
 
 CSS = """
 :root{


### PR DESCRIPTION
## Why

The static site is deployed and renders, but earlier Flet/Pyodide deploys registered a **Flutter service worker** at the `/portfolioMauricioobgo/` scope. Service workers aggressively cache and keep controlling the page across deploys, so returning visitors (including the repo owner on mobile) can keep being served the **old, broken bundle from cache** even after a good deploy — which matches "still blank after it deployed."

## What this does

Injects a tiny early `<script>` into the generated static `index.html` that:
- unregisters any existing service worker for the scope,
- deletes its caches,
- reloads once (guarded by `sessionStorage`) so the page is no longer controlled by the stale worker.

It's a no-op for first-time visitors and on browsers without service workers. One file changed (`build_static_site.py`); built on top of #48.

## Verification

- Official ruff wheel: format-check + lint clean
- `pytest tests/test_build_static_site.py` → 3 passed
- Headless Chromium re-render: still renders, **zero console errors, zero failed requests**

After merge + deploy, your next visit to `https://mauricioobgo.github.io/portfolioMauricioobgo/` will auto-drop the old cached Flet worker and show the static site.

https://claude.ai/code/session_01Ci7d6weLrV3WMBkWwQUMCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ci7d6weLrV3WMBkWwQUMCT)_